### PR TITLE
Add missing `afmm_param` argument when calling `listings_server`.

### DIFF
--- a/R/check_call_auto.R
+++ b/R/check_call_auto.R
@@ -4,7 +4,7 @@
 
 # dv.listings::mod_listings
 check_mod_listings_auto <- function(afmm, datasets, module_id, dataset_names, default_vars, pagination,
-    intended_use_label, warn, err) {
+    intended_use_label, subjid_var, receiver_id, warn, err) {
     OK <- logical(0)
     used_dataset_names <- new.env(parent = emptyenv())
     OK[["module_id"]] <- CM$check_module_id("module_id", module_id, warn, err)
@@ -12,13 +12,19 @@ check_mod_listings_auto <- function(afmm, datasets, module_id, dataset_names, de
     OK[["dataset_names"]] <- CM$check_dataset_name("dataset_names", dataset_names, flags, datasets, used_dataset_names,
         warn, err)
     "NOTE: default_vars (group) has no associated automated checks"
-    "      The expectation is that it does not require one or that"
+    "      The expectation is that it either does not require them or that"
     "      the caller of this function has written manual checks near the call site."
     "NOTE: pagination (group) has no associated automated checks"
-    "      The expectation is that it does not require one or that"
+    "      The expectation is that it either does not require them or that"
     "      the caller of this function has written manual checks near the call site."
     "NOTE: intended_use_label (group) has no associated automated checks"
-    "      The expectation is that it does not require one or that"
+    "      The expectation is that it either does not require them or that"
+    "      the caller of this function has written manual checks near the call site."
+    "NOTE: subjid_var (group) has no associated automated checks"
+    "      The expectation is that it either does not require them or that"
+    "      the caller of this function has written manual checks near the call site."
+    "NOTE: receiver_id (group) has no associated automated checks"
+    "      The expectation is that it either does not require them or that"
     "      the caller of this function has written manual checks near the call site."
     return(OK)
 }

--- a/R/mod_listings.R
+++ b/R/mod_listings.R
@@ -491,7 +491,8 @@ mod_listings <- function(
         module_id = module_id,
         intended_use_label = intended_use_label,
         subjid_var = subjid_var,
-        receiver_id = receiver_id
+        receiver_id = receiver_id,
+        afmm_param = list(utils = afmm$utils, module_names = afmm$module_names)
       )
     },
     module_id = module_id
@@ -535,8 +536,7 @@ check_mod_listings <- function(afmm, datasets, module_id, dataset_names,
   ok <- check_mod_listings_auto(
     afmm, datasets,
     module_id, dataset_names, default_vars, pagination, intended_use_label,
-    subjid_var, receiver_id
-    #warn, err
+    subjid_var, receiver_id, warn, err
   )
   
   # default_vars 

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -10,7 +10,7 @@ vdoc <- local({
 specs <- vdoc[["specs"]]
 #  validation (F)
 
-# YT#VH19ec235e56cdd18f129215603abf0ca6#VH00000000000000000000000000000000#
+# YT#VH27d48516d3cbdadbf92a7b5e0860b78e#VH19ec235e56cdd18f129215603abf0ca6#
 
 #' Test harness for communication with `dv.papo`.
 #'


### PR DESCRIPTION
The "jump-to-papo" test problem seems to be that `mod_listings` does not set a value for the `afmm_param` argument in its call to `listings_server`:

![image](https://github.com/user-attachments/assets/dc4c6cfb-70d9-455e-aad8-92da6c3e8e17)

The test application crashes because listings_server calls `afmm$utils$switch2mod(...)` on a NULL `afmm` inside an observer.

I've added the missing argument following the style of the `dv.clinlines` codebase, which `dv.listings` appears to emulate.