### PR TITLE
Sync shared code

### DIFF
--- a/R/CM.R
+++ b/R/CM.R
@@ -1,7 +1,7 @@
-# YT#VH0ae1b0c3bf862b3b93194fa0f023686d#VHd74cfd54b905c92b95c251b87af2e842#
+# YT#VHa53bd254d6ac8e6a19dfa057febb06b5#VH00000000000000000000000000000000#
 CM <- local({ # _C_hecked _M_odule
-  message_well <- function(title, contents, color = "f5f5f5") { # repeats #iewahg
-    style <- sprintf(r"---(
+  message_well <- function(title, contents, color = "f5f5f5") {
+    style <- sprintf("
       padding: 0.5rem;
       padding-left: 1rem;
       margin-bottom: 20px;
@@ -10,7 +10,7 @@ CM <- local({ # _C_hecked _M_odule
       border-radius: 4px;
       -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.05);
       box-shadow: inset 0 1px 1px rgba(0,0,0,.05);
-    )---", color)
+    ", color)
 
     res <- list(shiny::h3(title))
     if (length(contents)) res <- append(res, list(shiny::tags[["div"]](contents, style = style)))
@@ -31,7 +31,7 @@ CM <- local({ # _C_hecked _M_odule
     return(res)
   }
 
-  app_creator_feedback_server <- function(id, warning_messages, error_messages) {
+  app_creator_feedback_server <- function(id, warning_messages, error_messages, preface) {
     id <- paste(c(id, "validator"), collapse = "-")
     module <- shiny::moduleServer(
       id,
@@ -50,10 +50,13 @@ CM <- local({ # _C_hecked _M_odule
           err <- error_messages
           if (length(err)) {
             res[[length(res) + 1]] <-
-              message_well("Module configuration errors",
-                Map(function(x) htmltools::p(htmltools::HTML(paste("\u2022", x))), err),
-                color = "#f4d7d7"
-              )
+              message_well("Module configuration errors", {
+                tmp <- Map(function(x) htmltools::p(htmltools::HTML(paste("\u2022", x))), err)
+                if (!is.null(preface)) {
+                  tmp <- append(list(htmltools::p(htmltools::HTML(preface))), tmp)
+                }
+                tmp
+              }, color = "#f4d7d7")
           }
 
           return(res)
@@ -69,8 +72,11 @@ CM <- local({ # _C_hecked _M_odule
     return(module)
   }
 
-  # Wrap the UI and server of a module so that, once parameterized, they go through a check function prior to running.
-  module <- function(module, check_mod_fn, dataset_info_fn) {
+  # Wrap the UI and server of a module so that, once parameterized, they:
+  # - go through a check function prior to running
+  # - provide `dataset_info` to module manager
+  # - transform afmm arbitrarily to allow simplifying the logic of the module (e.g. mapping character columns to factors)
+  module <- function(module, check_mod_fn, dataset_info_fn, map_afmm_fn = NULL) {
     local({
       # Make sure that the signature of `check_mod_fn` matches that of `module` except for the expected differences
       check_formals <- names(formals(check_mod_fn))
@@ -103,6 +109,7 @@ CM <- local({ # _C_hecked _M_odule
 
       matched_args <- try(as.list(match.call(module)), silent = TRUE)
       error_message <- attr(matched_args, "condition")$message
+      error_message_dataset_index <- NULL
       if (is.null(error_message)) {
         missing_args <- setdiff(mandatory_module_args, names(matched_args))
         if (length(missing_args)) {
@@ -136,53 +143,45 @@ CM <- local({ # _C_hecked _M_odule
               #       - Here we also have access to the original datasets, which allows us to ensure call
               #         correctness independent of filter state or operation in a single pass.
               #       - "catch errors early"
-
-              args <- append(
-                list(
-                  afmm = afmm, # To check receiver_ids, among others
-                  datasets = afmm[["data"]][[1]] # Allows data checks prior to reactive time
-                ),
-                args
+              for (i_dataset in seq_along(afmm[["data"]])) {
+                check_args <- append(
+                  list(
+                    afmm = afmm, # To check receiver_ids, among others
+                    datasets = afmm[["data"]][[i_dataset]] # Allows data checks prior to reactive time
+                  ),
+                  args
+                )
+                res <- do.call(check_mod_fn, check_args)
+                # NOTE: Stop when errors are found on a single dataset to avoid overwhelming users with repeat messages
+                if (length(res[["errors"]])) { # NOTE: Not checking "warnings" because they are going away soon
+                  error_message_dataset_index <- i_dataset
+                  break
+                }
+              }
+            }
+            
+            if (!is.null(error_message_dataset_index) && length(afmm[["data"]]) > 1) {
+              dataset_name <- names(afmm[["data"]])[[error_message_dataset_index]]
+              res[["preface"]] <- paste(
+                "This application has been configured with more than one dataset.",
+                sprintf("The following error messages apply to the dataset named <b>%s</b>.<br>", dataset_name),
+                "No error checking has been performed on datasets specified after it. <hr>"
               )
-
-              # check functions do not have defaults, so we extract them from the formals of the module for consistency
-              missing_args <- setdiff(names(formals(module)), names(args))
-              res <- do.call(check_mod_fn, args)
             }
             return(res)
           })
 
           app_creator_feedback_server(
-            id = module_id, warning_messages = fb[["warnings"]], error_messages = fb[["errors"]]
+            id = module_id, warning_messages = fb[["warnings"]], error_messages = fb[["errors"]], 
+            preface = fb[["preface"]]
           )
 
-          # TODO: Modify afmm to the `map_to` flags in the API. `dv.papo` relies on this
-          # nolint start
-          if (FALSE) {
-            filtered_mapped_datasets <- shiny::reactive(
-              TC$honor_map_to_flag(afmm$filtered_dataset(), mod_lineplot_API, args)
-            )
-
-            bm_dataset <- shiny::reactive({
-              shiny::req(bm_dataset_name)
-              ds <- filtered_mapped_datasets()[[bm_dataset_name]]
-              shiny::validate(
-                shiny::need(!is.null(ds), paste("Could not find dataset", bm_dataset_name))
-              )
-              return(ds)
-            })
-
-            # TODO:
-            corr_hm_server(
-              id = module_id,
-              bm_dataset = bm_dataset,
-              default_value = default_value, subjid_var = subjid_var, cat_var = cat_var, par_var = par_var,
-              visit_var = visit_var, value_vars = value_vars
-            )
-          }
-          # nolint end
-
           if (length(fb[["errors"]]) == 0) {
+            if (!is.null(map_afmm_fn)) {
+              afmm_and_args <- append(list(afmm = afmm), args)
+              afmm <- do.call(map_afmm_fn, afmm_and_args)
+            }
+            
             res <- try(module_server(afmm), silent = TRUE)
           }
 
@@ -310,22 +309,23 @@ CM <- local({ # _C_hecked _M_odule
     return(res)
   }
 
+  style_code <- function(code) {
+    s <- paste(code, collapse = "")
+    s <- parse(text = s, keep.source = FALSE)[[1]] |>
+      deparse(width.cutoff = 100) |>
+      trimws("right") |>
+      paste(collapse = "\n")
+    return(s)
+  }
+
   # NOTE: For the moment call by running: devtools::load_all(); CM$generate_check_functions()
   generate_check_functions <- function(specs = module_specifications, output_file = "R/check_call_auto.R") {
+    # TODO: Fuse with generate_map_afmm_functions
     styler_off <- "({\n# styler: off"
     styler_on <- "\n\n})\n# styler: on\n"
 
     res <- c("# Automatically generated module API check functions. Think twice before editing them manually.\n")
     res <- c(res, styler_off)
-
-    style_code <- function(code) {
-      s <- paste(code, collapse = "")
-      s <- parse(text = s, keep.source = FALSE)[[1]] |>
-        deparse(width.cutoff = 100) |>
-        trimws("right") |>
-        paste(collapse = "\n")
-      return(s)
-    }
 
     for (spec_name in names(specs)) {
       if (!grepl("::", spec_name, fixed = TRUE)) stop(paste("Expected API spec name to be namespaced (`::`):", spec_name))
@@ -335,6 +335,114 @@ CM <- local({ # _C_hecked _M_odule
       res <- c(
         res,
         c(check_function_name, "<-", generate_check_function(specs[[spec_name]])) |> style_code()
+      )
+    }
+
+    res <- c(res, styler_on)
+
+    contents <- paste(res, collapse = "")
+    writeChar(contents, output_file, eos = NULL)
+
+    return(NULL)
+  }
+  
+  generate_map_afmm_function <- function(spec, module_name) {
+    stopifnot(spec$kind == "group")
+   
+    # TODO: At the time of writing, this code generator is only used by dv.explorer.parameter and it covers its needs.
+    #       It modifies afmm[["filtered_dataset"]] based on parameters flagged as "map_character_to_factor"
+    #       so that specific columns of target datasets are transformed to factors prior to going into a module.
+    #
+    #       In order to complete this functionality, we would have to map afmm[["unfiltered_dataset"]] as well
+    #       as afmm[["data"]]. Moreover, we would have to look for "map_character_to_factor" flags inside possibly 
+    #       nested column definitions, such as those used in papo.
+    
+    res <- character(0)
+    
+    push <- function(s) res <<- c(res, s)
+    push("function(afmm, ")
+    param_names <- paste(names(spec$elements), collapse = ",")
+    push(param_names)
+    push("){\n")
+    
+    push("res <- afmm\n")
+    
+    elements_that_require_mapping <- character(0)
+    for (elem_name in names(spec$elements))
+      if (isTRUE(attr(spec$elements[[elem_name]], "map_character_to_factor")))
+        elements_that_require_mapping <- c(elements_that_require_mapping, elem_name)
+    
+    if (length(elements_that_require_mapping)) {
+      push("mapping_summary <- character(0)\n")
+      push("for(ds_name in names(afmm[['data']])){\n")
+      push("  ds <- afmm[['data']][[ds_name]]\n")  
+      for (elem_name in elements_that_require_mapping){
+        elem <- spec$elements[[elem_name]]
+        stopifnot(elem$kind == "col")
+        dataset_name <- elem[["dataset_name"]]
+        push(sprintf("if(is.character(ds[[%s]][[%s]])){\n", dataset_name, elem_name))
+        push("mapping_summary <- c(mapping_summary,")
+        push(sprintf("paste0('(', ds_name, ') ', %s, '[[\"', %s, '\"]]')", dataset_name, elem_name))
+        push(")\n")
+        push("}\n")
+      }
+      push("}\n")
+      
+      push("if(length(mapping_summary)){\n")
+     
+      push(
+        paste0(
+          "warning_message <- paste0('[", module_name,
+          "] This module will map the following dataset columns from `character` to `factor`:\\n', ",
+          "paste(mapping_summary, collapse = ', '), '.\\nThe extra memory cost associated to this operation can be ",
+          "avoided by turning those columns into factors during data pre-processing.')\n",
+          "warning(warning_message)\n"
+        )
+      )
+      
+      push("res[['filtered_dataset']] <- shiny::reactive({\n")
+      push("  res <- afmm[['filtered_dataset']]()\n")
+      
+      for (elem_name in elements_that_require_mapping){
+        elem <- spec$elements[[elem_name]]
+        dataset_name <- elem[["dataset_name"]]
+        
+        push(sprintf("if (is.character(res[[%s]][[%s]])) {\n", dataset_name, elem_name))
+        push(sprintf("  res[[%s]][[%s]] <- ", dataset_name, elem_name))
+        push(sprintf("    as.factor(res[[%s]][[%s]])\n", dataset_name, elem_name))
+        push("}\n")
+      }
+      
+      push("  return(res)\n")
+      push("})\n")
+      push("}\n")
+    }
+    
+    push("return(res)\n")
+    push("}\n")
+
+    return(res)
+  }
+
+  # NOTE: For the moment, call by running: devtools::load_all(); CM$generate_map_afmm_functions()
+  generate_map_afmm_functions <- function(specs = module_specifications, output_file = "R/map_afmm_auto.R") {
+    # TODO: Fuse with generate_check_functions
+    styler_off <- "({\n# styler: off"
+    styler_on <- "\n\n})\n# styler: on\n"
+
+    res <- c("# Automatically generated module API afmm mapping functions. Think twice before editing them manually.\n")
+    res <- c(res, styler_off)
+
+    for (spec_name in names(specs)) {
+      if (!grepl("::", spec_name, fixed = TRUE)) stop(paste("Expected API spec name to be namespaced (`::`):", spec_name))
+      denamespaced_spec_name <- strsplit(spec_name, "::")[[1]][[2]]
+      map_afmm_function_name <- paste0("map_afmm_", denamespaced_spec_name, "_auto")
+      res <- c(res, sprintf("\n\n# %s\n", spec_name))
+      
+      res <- c(
+        res,
+        c(map_afmm_function_name, "<-", 
+          generate_map_afmm_function(specs[[spec_name]], module_name = denamespaced_spec_name)) |> style_code()
       )
     }
 
@@ -420,9 +528,38 @@ CM <- local({ # _C_hecked _M_odule
       return(TRUE)
     }
 
-    ok <- FALSE
-
+    ok <- assert(err, is.character(value), 
+                 paste(sprintf("The value assigned to parameter `%s` should be of type `character`", name),
+                       sprintf("and it's instead of type `%s`.", class(value)[[1]])))
+    
     valid_column_names <- list_columns_of_kind(dataset_value, subkind)
+    invalid_column_names <- value[!value %in% valid_column_names]
+    wrong_subkind_column_names <- invalid_column_names[invalid_column_names %in% names(dataset_value)]
+
+    ok <- ok && assert(
+      err, length(wrong_subkind_column_names) == 0, {
+        cnames <- paste(sprintf('"%s"', wrong_subkind_column_names), collapse = ", ")
+        type_desc <- TC$get_type_as_text(subkind)
+        types_found <- unname(sapply(dataset_value[wrong_subkind_column_names], function(x) class(x)[[1]]))
+        types_found_desc <- paste(sprintf("`%s`", types_found), collapse = ", ")
+        paste(
+          sprintf("Variables assigned to parameter <b>`%s`</b> should refer to columns of dataset <b>`%s`</b>",
+                  name, dataset_name),
+          sprintf("of type `%s`, but some (<b>%s</b>) have other types (%s).", 
+                  type_desc, cnames, types_found_desc)
+        )
+      }
+    )
+    
+    ok <- ok && assert(
+      err, length(invalid_column_names) == 0, {
+        cnames <- paste(sprintf('"%s"', invalid_column_names), collapse = ", ")
+        paste(
+          sprintf("The value of parameter <b>`%s`</b> includes one or more variables (<b>%s</b>)", name, cnames),
+          sprintf("that are not columns of the <b>`%s`</b> dataset.", dataset_name)
+        )
+      }
+    )
 
     zero_or_more <- isTRUE(flags[["zero_or_more"]])
     one_or_more <- isTRUE(flags[["one_or_more"]])
@@ -430,26 +567,24 @@ CM <- local({ # _C_hecked _M_odule
     if (zero_or_one_or_more) {
       min_len <- 0
       if (one_or_more) min_len <- 1
-      ok <- assert(
+      
+      ok <- ok && assert(
         err,
-        is.character(value) &&
-          all(value %in% valid_column_names) &&
-          length(value) >= min_len,
-        paste(
-          sprintf(
-            "`%s` should be a character vector of length greater than %s referring to one of the following columns of dataset `%s`: ",
-            name, c("zero", "one")[[min_len + 1]], dataset_name
-          ),
-          paste(sprintf('"%s"', valid_column_names), collapse = ", "), "."
-        )
+        length(value) >= min_len, {
+          col_names <- paste(sprintf('"%s"', valid_column_names), collapse = ", ")
+          paste0(
+            sprintf("`%s` should be a character vector of length greater than %s ", name, c("zero", "one")[[min_len + 1]]),
+            sprintf("referring to the following columns of dataset `%s`: ", dataset_name),
+            col_names, "."
+          )
+        }
       )
     } else {
-      ok <- assert(
+      ok <- ok && assert(
         err,
-        test_string(value) &&
-          all(value %in% valid_column_names),
+        length(value) == 1,
         paste(
-          sprintf("`%s` should be a string referring to one of the following columns of dataset `%s`: ", name, dataset_name),
+          sprintf("`%s` should be a string referring to a single column of dataset `%s`: ", name, dataset_name),
           paste(sprintf('"%s"', valid_column_names), collapse = ", "), "."
         )
       )
@@ -464,7 +599,7 @@ CM <- local({ # _C_hecked _M_odule
     } else if (is.character(v)) {
       res <- sprintf('"%s"', unique(v))
     } else {
-      browser()
+      stop(sprintf('Unsuported class "%s" as argument to `list_values`', class(v)))
     }
 
     res <- paste(res, collapse = ", ")
@@ -514,7 +649,7 @@ CM <- local({ # _C_hecked _M_odule
   check_choice_from_col_contents <- function(name, value, flags, dataset_name, dataset_value, column, warn, err) {
     ok <- check_flags(name, value, flags, warn, err) &&
       assert(
-        err, all(value %in% dataset_value[[column]]),
+        err, is.null(value) || all(value %in% dataset_value[[column]]),
         sprintf(
           "`%s` should contain only values present in column `%s` of dataset `%s`: %s.",
           name, column, dataset_name, list_values(dataset_value[[column]])
@@ -538,7 +673,7 @@ CM <- local({ # _C_hecked _M_odule
   }
 
   format_inline_asis <- function(s) {
-    paste("<code style='white-space: pre; color:#333'>", s, "</code>")
+    paste0("<code style='white-space: pre; color:#333'>", s, "</code>")
   }
 
   check_function <- function(name, value, arg_count, flags, warn, err) {
@@ -583,37 +718,93 @@ CM <- local({ # _C_hecked _M_odule
     dataset <- datasets[[ds_value]]
 
     unique_cat_par_combinations <- unique(dataset[c(cat, par)])
-    dup_params_across_categories <- duplicated(unique_cat_par_combinations[par])
+    dup_mask <- duplicated(unique_cat_par_combinations[par])
+    
+    ok <- assert(err, !any(dup_mask), {
+      unique_repeat_params <- unique_cat_par_combinations[[par]][dup_mask]
+      dups <- df_to_string(
+        data.frame(
+          check.names = FALSE,
+          Parameter = unique_repeat_params,
+          "Inside categories" = sapply(
+            unique_repeat_params, function(param) {
+              dup_mask <- (unique_cat_par_combinations[[par]] == param)
+              return(paste(unique_cat_par_combinations[dup_mask, ][[cat]], collapse = ", "))
+            }
+          )
+        )
+      )
+      prefix_repeat_params_command <- 
+        sprintf('%s <- dv.explorer.parameter::prefix_repeat_parameters(%s, cat_var = "%s", par_var = "%s")', 
+                ds_value, ds_value, cat, par)
 
-    ok <- assert(err, !any(dup_params_across_categories), {
-      prefixes <- c(rep("Category:", length(cat)), rep("Parameter:", length(par)))
-      first_duplicates <- head(unique_cat_par_combinations[dup_params_across_categories, ], 5)
+      mask <- unique_cat_par_combinations[["PARAM"]] %in% unique_repeat_params
+      deduplicated_table <- df_to_string({
+        cats <- unique_cat_par_combinations[mask, ][[cat]]
+        pars <- unique_cat_par_combinations[mask, ][[par]]
+        data.frame(
+          check.names = FALSE,
+          Category = cats, "Old parameter name" = pars, "New parameter name" = paste0(cats, "-", pars)
+        )
+      })
 
-      names(first_duplicates) <- paste(prefixes, names(first_duplicates))
-      dups <- df_to_string(first_duplicates)
-      paste(
-        sprintf("The dataset provided by `%s` (%s) contains parameter names that repeat across categories.", ds_name, ds_value),
-        "This module expects them to be unique. Here are the first few duplicates:",
-        paste0("<pre>", dups, "</pre>")
+      paste0(
+        sprintf('The dataset provided by %s ("%s") contains parameter names that repeat across categories.', 
+                format_inline_asis(ds_name), ds_value),
+        "This module expects them to be unique. This is the list of duplicates:",
+        paste0("<pre>", dups, "</pre>"),
+        "In order to bypass this issue, we suggest you preprocess that dataset with this command:",
+        paste0("<pre>", prefix_repeat_params_command, "</pre>"),
+        sprintf('<small><i>In case the dataset labeled as "%s" has a different name in your application code, ', ds_value),
+        "substitute it with the actual name of the variable holding that dataset.</i></small><br>",
+        "The ", format_inline_asis("dv.explorer.parameter::prefix_repeat_parameters"), " function ",
+        "will rename the repeat parameters by prefixing them with the category they belong to, as shown on this table:",
+        "<pre>", deduplicated_table, "</pre>"
       )
     })
 
     supposedly_unique <- dataset[c(sub, cat, par, vis)]
-    dups <- duplicated(supposedly_unique)
+    dup_mask <- duplicated(supposedly_unique)
 
-    ok <- ok && assert(err, !any(dups), {
+    ok <- ok && assert(err, !any(dup_mask), {
       prefixes <- c(
         rep("Subject:", length(sub)), rep("Category:", length(cat)),
         rep("Parameter:", length(par)), rep("Visit:", length(vis))
       )
 
-      first_duplicates <- head(supposedly_unique[dups, ], 5)
+      first_duplicates <- head(supposedly_unique[dup_mask, ], 5)
       names(first_duplicates) <- paste(prefixes, names(first_duplicates))
       dups <- df_to_string(first_duplicates)
+      
+      unique_repeats <- unique(supposedly_unique[dup_mask, ])
+      target <- unique_repeats[1, ]
+      target_rows <- which(supposedly_unique[[sub]] == target[[sub]] & supposedly_unique[[cat]] == target[[cat]] &
+                             supposedly_unique[[par]] == target[[par]] & supposedly_unique[[vis]] == target[[vis]])
+      
+      row_a <- dataset[target_rows[[1]], ]
+      row_b <- dataset[target_rows[[2]], ]
+      diff_cols <- character(0)
+      for (col in names(row_a)) if (!identical(row_a[[col]], row_b[[col]])) diff_cols <- c(diff_cols, col)
+     
+      col_diff_report <- "are identical." 
+      if (length(diff_cols)) { 
+        col_diff_report <- paste0(
+          "have indeed identical subject, category, parameter and visit values, but differ in columns: ",
+          paste(diff_cols, collapse = ", "), ".",
+          "<pre>", 
+          df_to_string(dataset[target_rows[1:2], c(sub, cat, par, vis, diff_cols)]),
+          "</pre>"
+        )
+      }
+        
       paste(
         sprintf("The dataset provided by `%s` (%s) contains repeated rows with identical subject, category, parameter", ds_name, ds_value),
-        "and visit values. This module expects them to be unique. Here are the first few duplicates:",
-        paste0("<pre>", dups, "</pre>")
+        sprintf("and visit values. This module expects them to be unique. There are a total of %d duplicates.", sum(dup_mask)),
+        "Here are the first few:",
+        paste0("<pre>", dups, "</pre>"),
+        sprintf("These findings can be partially confirmed by examining that rows <b>%d</b> and <b>%d</b> of that dataset", 
+                target_rows[[1]], target_rows[[2]]),
+        col_diff_report
       )
     })
 
@@ -625,6 +816,7 @@ CM <- local({ # _C_hecked _M_odule
     container = container,
     assert = assert,
     generate_check_functions = generate_check_functions,
+    generate_map_afmm_functions = generate_map_afmm_functions,
     check_module_id = check_module_id,
     check_dataset_name = check_dataset_name,
     check_dataset_colum_name = check_dataset_colum_name,

--- a/R/TC.R
+++ b/R/TC.R
@@ -1,4 +1,4 @@
-# YT#VH5cf018ae9cef0cbf83422a7d2b6b6b04#VH00000000000000000000000000000000#
+# YT#VH1202cc468f3cbf448dd25ff917fc4762#VH00000000000000000000000000000000#
 TC <- local({ # _T_ype C_hecks
   # basic types
   T_logical <- function() list(kind = "logical")
@@ -71,9 +71,16 @@ TC <- local({ # _T_ype C_hecks
     unknown_flags <- setdiff(
       flag_names,
       c( # common flags
-        "optional", "zero_or_more", "one_or_more", "as_array", "named", "ignore",
+        "optional",                   # parameter can be skipped
+        "zero_or_more",               # array/list contains a variable number of elements
+        "one_or_more",                # array/list contains at least one element and possibly more
+        "as_array",                   # list is converted to array for the sake of implementation simplicity (miguel: I believe it's only used in papo)
+        "named",                      # elements of targetted argument must be named
+        "map_character_to_factor",    # the target TC$col() will be transformed to factor prior to reaching the module
+        "ignore",                     # argument should be ignored by Dressing Room, for now
         # domain-specific flags
-        "subject_level_dataset_name", "subjid_var"
+        "subject_level_dataset_name", # indicates dataset with one row per subject
+        "subjid_var"                  # indicates unique subject identifier column on dataset pointed at by subject_level_dataset_name 
       )
     )
     if (length(unknown_flags)) browser()
@@ -362,6 +369,7 @@ TC <- local({ # _T_ype C_hecks
     honor_as_array_flag_inner = T_honor_as_array_flag_inner,
     honor_as_array_flag = T_honor_as_array_flag,
     honor_map_to_flag_inner = T_honor_map_to_flag_inner,
-    honor_map_to_flag = T_honor_map_to_flag
+    honor_map_to_flag = T_honor_map_to_flag,
+    get_type_as_text = T_get_type_as_text
   )
 })

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -10,7 +10,7 @@ vdoc <- local({
 specs <- vdoc[["specs"]]
 #  validation (F)
 
-# YT#VH27d48516d3cbdadbf92a7b5e0860b78e#VH19ec235e56cdd18f129215603abf0ca6#
+# YT#VH0bf15c0db690dfd3fac713f3c9b61f66#VH00000000000000000000000000000000#
 
 #' Test harness for communication with `dv.papo`.
 #'
@@ -18,7 +18,7 @@ specs <- vdoc[["specs"]]
 #' @param data Data matching the previous parameterization.
 #' @param trigger_input_id Fully namespaced input ID that, when set to a subject ID value,
 #'                         should make the module send `dv.papo` a message.
-test_communication_with_papo <- function(mod, data, trigger_input_id) {
+test_communication_with_papo <- function(mod, data, trigger_input_id, papo_spec_id, papo_spec_text) {
   datasets <- shiny::reactive(data)
 
   afmm <- list(
@@ -50,8 +50,8 @@ test_communication_with_papo <- function(mod, data, trigger_input_id) {
 
   app <- shiny::shinyApp(ui = app_ui, server = app_server)
 
-  testthat::test_that("module adheres to send_subject_id_to_papo protocol" %>% 
-    vdoc[["add_spec"]](specs$jumping_feature), { 
+  testthat::test_that("module adheres to send_subject_id_to_papo protocol" |>
+    vdoc[["add_spec"]](papo_spec_text, papo_spec_id), { 
     app <- shinytest2::AppDriver$new(app, name = "test_send_subject_id_to_papo_protocol")
 
     app$wait_for_idle()

--- a/tests/testthat/test-message_papo.R
+++ b/tests/testthat/test-message_papo.R
@@ -29,4 +29,4 @@ mod <- dv.listings::mod_listings(
 )
 
 trigger_input_id <- "mod-selected_subject_id"
-test_communication_with_papo(mod, data_list, trigger_input_id)
+test_communication_with_papo(mod, data_list, trigger_input_id, "specs$jumping_feature", specs$jumping_feature)

--- a/tests/testthat/test-message_papo.R
+++ b/tests/testthat/test-message_papo.R
@@ -29,4 +29,4 @@ mod <- dv.listings::mod_listings(
 )
 
 trigger_input_id <- "mod-selected_subject_id"
-test_communication_with_papo(mod, data_list, trigger_input_id, "specs$jumping_feature", specs$jumping_feature)
+test_communication_with_papo(mod, data_list, trigger_input_id, "jumping_feature", specs$jumping_feature)


### PR DESCRIPTION
This PR updates the shared code snippets on this repo to the latest version available:
- The "test communication with papo" snippet (`tests/testthat/test_message_pap.R`) now defines a validation identifier for the test. That is provided from `tests/testthat/setup.R`
- The `CM.R` (checked module) and `TC.R` (type checks) files don't require any change to the package.