### PR TITLE
Require explicit `tracked_vars` instead of `untracked_vars` subfield.

### DIFF
--- a/R/mock_listings.R
+++ b/R/mock_listings.R
@@ -214,7 +214,14 @@ mock_cqm <- function() {
     # Jumping to the Patient Profile module is possible, provided that it is included as well:
     receiver_id = "papo",
     review = list(
-      datasets = list(ae = list(id_vars = c("USUBJID", "AESEQ"), untracked_vars = c())),
+      datasets = list(
+        ae = list(
+          id_vars = c("USUBJID", "AESEQ"), 
+          tracked_vars = c(
+            "AESEV", "RFXSTDTC", "RFSTDTC", "AETERM", "AEHLGT", "AEHLT", "AELLT", 
+            "AEDECOD", "AESOC", "AESTDTC", "AEENDTC", "AEOUT", "AEACN", "AEREL"
+          ))
+      ),
       choices = c("Pending", "Reviewed with no issues", "Action required", "Resolved"),
       roles = c("TSTAT", "SP", "Safety", "CTL"),
       store_path = tempdir()

--- a/R/mod_listings.R
+++ b/R/mod_listings.R
@@ -896,8 +896,8 @@ check_mod_listings <- function(afmm, datasets, module_id, dataset_names,
         CM$assert(
           container = err,
           cond = (checkmate::test_list(review, names = "unique") &&
-                    checkmate::test_subset(c("id_vars", "untracked_vars"), names(info))),
-          msg = sprintf("`review$datasets$%s` should be a list with two elements named `id_vars` and `untracked_vars`",
+                    checkmate::test_subset(c("id_vars", "tracked_vars"), names(info))),
+          msg = sprintf("`review$datasets$%s` should be a list with two elements named `id_vars` and `tracked_vars`",
                         domain)
         ) &&
           CM$assert(
@@ -919,11 +919,11 @@ check_mod_listings <- function(afmm, datasets, module_id, dataset_names,
           ) &&
           CM$assert(
             container = err,
-            cond = (checkmate::test_character(info[["untracked_vars"]], min.chars = 1, unique = TRUE, null.ok = TRUE) &&
-                      checkmate::test_subset(info[["untracked_vars"]], names(dataset))),
+            cond = (checkmate::test_character(info[["tracked_vars"]], min.chars = 1, unique = TRUE) &&
+                      checkmate::test_subset(info[["tracked_vars"]], names(dataset))),
             msg = sprintf(
               paste(
-                "`review$datasets$%s$untracked_vars` should be a character vector listing a subset of the columns",
+                "`review$datasets$%s$tracked_vars` should be a character vector listing a subset of the columns",
                 "available in dataset `%s`"
               ), domain, domain
             )

--- a/R/review.R
+++ b/R/review.R
@@ -168,8 +168,7 @@ REV_load_annotation_info <- function(folder_contents, review, dataset_lists) {
                                    data_timestamp = numeric(row_count))
       
       id_vars <- review[["datasets"]][[dataset_review_name]][["id_vars"]]
-      untracked_vars <- review[["datasets"]][[dataset_review_name]][["untracked_vars"]]
-      tracked_vars <- setdiff(names(dataset), c(id_vars, untracked_vars))
+      tracked_vars <- setdiff(review[["datasets"]][[dataset_review_name]][["tracked_vars"]], id_vars)
      
       base_timestamp <- NA_real_
       data_timestamps <- rep(NA_real_, row_count)
@@ -215,7 +214,7 @@ REV_load_annotation_info <- function(folder_contents, review, dataset_lists) {
             # This code is guarded by a conditional because if `id_vars` is modified, `tracked_vars` will likely be 
             # affected as a side effect. In that situation, this error is insignificant, so we don't notify it.
             cur_tracked_vars <- base_info[["tracked_vars"]]
-            new_tracked_vars <- sort(setdiff(names(dataset), c(id_vars, untracked_vars)))
+            new_tracked_vars <- sort(tracked_vars)
             if (!identical(cur_tracked_vars, new_tracked_vars)) {
               extra_vars <- setdiff(new_tracked_vars, cur_tracked_vars)
               if (length(extra_vars)) {
@@ -226,7 +225,7 @@ REV_load_annotation_info <- function(folder_contents, review, dataset_lists) {
                     "[", dataset_review_name, "] ",
                     "The following variables were not available on a previous iteration of the review process: ",
                     paste(sprintf('"%s"', extra_vars), collapse = ", "), ".\n",
-                    "Please, specify them as as \"untracked\" through the `untracked_vars` parameter."
+                    "Please, exclude them from the \"tracked_vars\" parameter."
                   )
                 )
               } 
@@ -237,7 +236,7 @@ REV_load_annotation_info <- function(folder_contents, review, dataset_lists) {
                   error, 
                   paste0(
                     "[", dataset_review_name, "] ",
-                    "The following variables are not available or have been specified as \"untracked\": ",
+                    "The following variables have not been specified as `tracked_vars`: ",
                     paste(sprintf('"%s"', missing_vars), collapse = ", "), ".\n",
                     "Previous runs of this tool were instructed to track them. Please, reinstate them."
                   )

--- a/vignettes/review_design_notes.Rmd
+++ b/vignettes/review_design_notes.Rmd
@@ -34,11 +34,11 @@ review = list(
   datasets = list(
     dm = list(
       id_vars = "USUBJID",
-      untracked_vars = character(0)
+      tracked_vars = c("RFSTDTC", "RFENDTC", "RFXSTDTC", "TFXENDTC", "DMDTC")
     ),
     ae = list(
       id_vars = c("USUBJID", "AESEQ"),
-      untracked_vars = character(0)
+      tracked_vars = c("AETERM", "AESTDTC", "AEENDTC", "AEOUT", "AEACN", "AEREL", "AESEV")
     ),
     ...
   ),
@@ -51,13 +51,13 @@ All leafs are of type `character(n)`, except for `review_store_path` which is op
 
 A possible simplification would be to make `"USUBJID"` optional on `id_vars`, since `subjid_var` is already a mandatory parameter to the module. The logic inside the module would be that `sorted(union(subjid_var, id_vars))` would be use to identify each row.
 
-**Beware**: Once the application is configured and run once, the only change permitted to the `datasets` subfield will be to *add* extra datasets. Changes to previously configured `id_vars` or `untracked_vars` sub-subfields could potentially render the collected review information inconsistent. The module should disallow the editing controls until such a situation is addressed. Review choices and roles do not suffer from that problem.
+**Beware**: Once the application is configured and run once, the only change permitted to the `datasets` subfield will be to *add* extra datasets. Changes to previously configured `id_vars` or `tracked_vars` sub-subfields could potentially render the collected review information inconsistent. The module should disallow the editing controls until such a situation is addressed. Review choices and roles do not suffer from that problem.
 
 ## Data Stability Requirements
 The module only has access to the latest version of any given dataset. In order to inform users about modified and newly added records, it relies on stored summary hashes of previously seen data. Thus, it is necessary that some aspects of the representation of data are kept constant over the life of a study. Currently, these are:
 
 - All rows of each provided dataset are identified uniquely by the combination of `id_vars` configured at the beginning of the study.
-- Identifying variables (defined through `id_vars`) and tracked variables (defined by removing both `id_vars` and `untracked_vars` from the target dataset) have to remain the same for the duration of the study.
+- Identifying variables (defined through `id_vars`) and tracked variables (defined through `tracked_vars`) have to remain the same for the duration of the study.
 - Identifying and tracked variables retain their types (factor, numeric, ...) and are available on each revision of each dataset.
 - No data rows are dropped during the study. In other words, if a combination of `id_vars` is present on revision `n` of a dataset, it will be available on revision `n+1`.
 


### PR DESCRIPTION
This PR flips the logic of the previous `untracked_vars` review subfield as discussed internally.
I'm not bumping the package version or providing a description, because this change is part of the API exploration of the review feature and only affects internal experimental testing.