### PR TITLE
Expand tracked_hash to two bytes per variable + misc

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# formatting
+23b125d3d44eda8230e873fcbd88f2a20175d087
+a5a5d133ad5ef0df7fd40be2ec4f9cd22ab0fa9d

--- a/.lintr.R
+++ b/.lintr.R
@@ -9,6 +9,7 @@ linters <- lintr::modify_defaults(
   , object_length_linter = NULL               # we don't type long var names just because
   , pipe_continuation_linter = NULL           # wickham being overly prescriptive
   , trailing_blank_lines_linter = NULL        # natural extension of trailing_whitespace_linter, present on the template
+  , semicolon_linter = NULL                   # used to highlight checks that lead to the early out on a function
 )
 
 if(identical(Sys.getenv('CI'), "true")){

--- a/R/mod_listings.R
+++ b/R/mod_listings.R
@@ -389,7 +389,7 @@ listings_server <- function(module_id,
       "clear_filters",
       # NOTE(miguel): Added here for easier merge with other branches
       # TODO(miguel): Move elsewhere after merging 
-      REV_UI(ns = ns, roles = review[["roles"]])[["input_ids_to_exclude_from_bookmarking"]]
+      REV_UI(ns = ns, roles = character(0))[["input_ids_to_exclude_from_bookmarking"]]
     ))
     
     # Bookmarking (end)
@@ -429,6 +429,10 @@ listings_server <- function(module_id,
       } else {
         fs_client <- fs_init(fs_callbacks, review[["store_path"]])
       }
+      
+      # Overly restrictive sanitization of role strings, as they will be used for file names:
+      # TODO: Consider adapting https://github.com/r-lib/fs/blob/main/R/sanitize.R instead to allow alternative charsets
+      review[["roles"]] <- gsub("[^a-zA-Z0-9 _.-]", "", review[["roles"]]) # Accepts alpha+num+space+'.'+'_'+'-'
 
       output[[TBL$REVIEW_UI_ID]] <- shiny::renderUI(
         shinyWidgets::dropdownButton(

--- a/R/mod_listings.R
+++ b/R/mod_listings.R
@@ -217,6 +217,11 @@ listings_UI <- function(module_id) { # nolint
 #' @param on_sbj_click `[function()]`
 #'
 #' Function to invoke when a subject ID is clicked in a listing
+#' 
+#' @param review `[list()]`
+#'
+#' Configuration of the experimental data review feature. 
+#' For more details, please refer to `vignette("data_review")`.
 #'
 #' @export
 listings_server <- function(module_id,

--- a/R/review.R
+++ b/R/review.R
@@ -69,7 +69,7 @@ REV_include_review_info <- function(annotation_info, data, col_names, extra_col_
 }
 
 REV_UI <- function(ns, roles) {
-  choices <- setNames(c("", roles), c("<select reviewer role>", make.names(roles)))
+  choices <- setNames(c("", roles), c("<select reviewer role>", roles))
 
   res <- list()
   res[["ui"]] <- shiny::tagList(
@@ -108,8 +108,6 @@ REV_load_annotation_info <- function(folder_contents, review, dataset_lists) {
     folder_IO_plan <<- c(folder_IO_plan, list(action))
   }
   
-  review[["roles"]] <- make.names(review[["roles"]])
-
   for (dataset_lists_name in names(dataset_lists)) {
     sub_res <- list()
     dataset_list <- dataset_lists[[dataset_lists_name]]
@@ -590,7 +588,7 @@ REV_logic_2 <- function(ns, state, input, review, datasets, selected_dataset_lis
       SH$double_to_raw(timestamp)
     )
     
-    fname <- paste0(dataset_name, "_", make.names(role), ".review")
+    fname <- paste0(dataset_name, "_", role, ".review")
 
     IO_plan <- list(
       list(

--- a/R/review_structures.R
+++ b/R/review_structures.R
@@ -1,25 +1,23 @@
-# nolint start
-
 BYTES_PER_TRACKED_HASH <- 2L
 
 SH <- local({ # _S_erialization _H_elpers
-  get_UTC_time_in_seconds <- function() as.numeric(structure(Sys.time(), tzone = 'UTC'))
-  double_to_raw <- function(v) writeBin(v, con = raw(0), endian = 'little', useBytes = TRUE)
-  integer_to_raw <- function(v) writeBin(v, con = raw(0), endian = 'little', useBytes = TRUE)
+  get_UTC_time_in_seconds <- function() as.numeric(structure(Sys.time(), tzone = "UTC"))
+  double_to_raw <- function(v) writeBin(v, con = raw(0), endian = "little", useBytes = TRUE)
+  integer_to_raw <- function(v) writeBin(v, con = raw(0), endian = "little", useBytes = TRUE)
   string_to_raw <- function(v) c(integer_to_raw(nchar(v)), charToRaw(v))
-  character_vector_to_raw <- function(v){
+  character_vector_to_raw <- function(v) {
     res <- integer_to_raw(length(v))
-    for(s in v) res <- c(res, string_to_raw(s))
+    for (s in v) res <- c(res, string_to_raw(s))
     return(res)
   }
-  integer_vector_to_raw <- function(v){
+  integer_vector_to_raw <- function(v) {
     res <- integer_to_raw(length(v))
-    for(s in v) res <- c(res, integer_to_raw(s))
+    for (s in v) res <- c(res, integer_to_raw(s))
     return(res)
   }
 
   ..ref_hash_id <- function(row) {
-    input <- paste(row, collapse = '\1D')
+    input <- paste(row, collapse = "\1D")
     input <- charToRaw(input)
     res <- xxhashlite::xxhash_raw(input, as_raw = TRUE)
     return(res)
@@ -28,7 +26,7 @@ SH <- local({ # _S_erialization _H_elpers
 ..ref_hash_tracked_inner <- function(row) {
     # FIXME: Ensure that precision of numeric values does not affect serialization
     #        Maybe by using a string hex representation of their binary contents
-    input <- paste(row, collapse = '\1D')
+    input <- paste(row, collapse = "\1D")
     input <- charToRaw(input)
     res <- xxhashlite::xxhash_raw(input, algo = "xxh32", as_raw = TRUE)
     return(res)
@@ -40,9 +38,9 @@ SH <- local({ # _S_erialization _H_elpers
     n_col <- length(row)
     
     res <- raw(BYTES_PER_TRACKED_HASH * n_col)
-    for(i_col in seq(n_col)){      
-      col_indices <- (((i_col-1) + hash_tracked_offsets) %% n_col) + 1
-      first <- BYTES_PER_TRACKED_HASH * (i_col-1) + 1
+    for (i_col in seq(n_col)){      
+      col_indices <- (((i_col - 1) + hash_tracked_offsets) %% n_col) + 1
+      first <- BYTES_PER_TRACKED_HASH * (i_col - 1) + 1
       last <- BYTES_PER_TRACKED_HASH * i_col
       res[first:last] <- ..ref_hash_tracked_inner(row[col_indices])[1:BYTES_PER_TRACKED_HASH] # most significant bytes
       i_col <- i_col + 1
@@ -68,37 +66,37 @@ SH <- local({ # _S_erialization _H_elpers
     res <- list()   
     for (i_col in seq_len(n_col)) {
       col_indices <- (((i_col - 1) + hash_tracked_offsets) %% n_col) + 1
-      res[[i_col]] <- vectorized_hash_row(df[col_indices], algo = "xxh32")[1:BYTES_PER_TRACKED_HASH,] # most significant bytes
+      res[[i_col]] <- vectorized_hash_row(df[col_indices], algo = "xxh32")[1:BYTES_PER_TRACKED_HASH, ] # MSBs
     }
     res <- do.call(rbind, res)
     return(res)
   }
 
-  read_string_from_con <- function(con){
+  read_string_from_con <- function(con) {
     res <- NULL
     n <- readBin(con, integer(), 1L)
-    if(length(n) > 0) res <- readBin(con, raw(), n) |> rawToChar()
+    if (length(n) > 0) res <- readBin(con, raw(), n) |> rawToChar()
     return(res)
   }
 
-  read_character_vector_from_con <- function(con){
+  read_character_vector_from_con <- function(con) {
     res <- character(0)
     n <- readBin(con, integer(), 1L)
-    for(i in seq_len(n)) res <- c(res, read_string_from_con(con))
+    for (i in seq_len(n)) res <- c(res, read_string_from_con(con))
     return(res)
   }
 
-  read_integer_vector_from_con <- function(con){
+  read_integer_vector_from_con <- function(con) {
     res <- integer(0)
-    n <- readBin(con, integer(), 1L, endian = 'little')
-    res <- readBin(con, integer(), n, endian = 'little')
+    n <- readBin(con, integer(), 1L, endian = "little")
+    res <- readBin(con, integer(), n, endian = "little")
     return(res)
   }
 
-  read_hashes_from_con <- function(con, hash_count, hash_length){
-    expected_hash_byte_count <- hash_count*hash_length
+  read_hashes_from_con <- function(con, hash_count, hash_length) {
+    expected_hash_byte_count <- hash_count * hash_length
     hash_vector <- readBin(con, raw(), expected_hash_byte_count)
-    ; if(length(hash_vector) < expected_hash_byte_count) return(simpleCondition("Not enough hash data"))
+    ; if (length(hash_vector) < expected_hash_byte_count) return(simpleCondition("Not enough hash data"))
     res <- array(hash_vector, dim = c(hash_length, hash_count))
     return(res)
   }
@@ -126,13 +124,13 @@ SH <- local({ # _S_erialization _H_elpers
 })
 
 # _R_eview _S_tructures
-RS_hash_data_frame <- function(df){
+RS_hash_data_frame <- function(df) {
   # Strip arguments from unnecessary detail
-  attributes(df) <- list(class = 'data.frame', names = names(df), row.names = seq_len(nrow(df)))
+  attributes(df) <- list(class = "data.frame", names = names(df), row.names = seq_len(nrow(df)))
   
   res <- xxhashlite::xxhash_raw(
     vec = serialize(object = df, connection = NULL, ascii = FALSE, xdr = FALSE, version = 3), 
-    algo = 'xxh128', as_raw = TRUE
+    algo = "xxh128", as_raw = TRUE
   )
   return(res)
 }
@@ -153,17 +151,17 @@ RS_variable_type_encoding <- list(
 )
 RS_variable_type_desc_from_code <- local({
   res <- character()
-  for(elem in RS_variable_type_encoding) res[[elem[["code"]]]] <- elem[["desc"]]
+  for (elem in RS_variable_type_encoding) res[[elem[["code"]]]] <- elem[["desc"]]
   return(res)
 })
 
-RS_compute_data_frame_variable_types <- function(df, vars){
+RS_compute_data_frame_variable_types <- function(df, vars) {
   res <- raw(length(vars))
-  for(i_var in seq_along(vars)){
+  for (i_var in seq_along(vars)){
     v <- 0
     var <- df[[vars[[i_var]]]]
-    for(encoding in RS_variable_type_encoding){
-      if(encoding[["fn"]](var)){
+    for (encoding in RS_variable_type_encoding){
+      if (encoding[["fn"]](var)) {
         v <- encoding[["code"]]
         break
       }
@@ -174,17 +172,17 @@ RS_compute_data_frame_variable_types <- function(df, vars){
   return(res)
 }
 
-RS_parse_data_frame_variable_types <- function(v){
+RS_parse_data_frame_variable_types <- function(v) {
   res <- RS_variable_type_desc_from_code[as.integer(v)]
   res[is.na(res)] <- "unknown"
   return(res)
 }
 
-RS_compute_id_hashes <- function(df, id_vars){
+RS_compute_id_hashes <- function(df, id_vars) {
   return(SH$hash_id(df[id_vars]))
 }
 
-RS_compute_base_memory <- function(df_id, df, id_vars, tracked_vars){
+RS_compute_base_memory <- function(df_id, df, id_vars, tracked_vars) {
   checkmate::assert_string(df_id, min.chars = 1, max.chars = 65535)
   checkmate::assert_data_frame(df)
   # TODO: assert *_vars char unique col names of df
@@ -196,11 +194,11 @@ RS_compute_base_memory <- function(df_id, df, id_vars, tracked_vars){
 
   # row hashes
   id_hashes <- RS_compute_id_hashes(df, id_vars)
-  ; if(!identical(dim(id_hashes), c(16L, nrow(df)))) return(simpleCondition("Internal error in id_vars hash preparation"))
-  ; if(any(duplicated(id_hashes, MARGIN = 2))) return(simpleCondition("Found duplicated IDs"))
+  ; if (!identical(dim(id_hashes), c(16L, nrow(df)))) return(simpleCondition("Internal error in id_vars hash preparation"))
+  ; if (any(duplicated(id_hashes, MARGIN = 2))) return(simpleCondition("Found duplicated IDs"))
 
   tracked_hashes <- SH$hash_tracked(df[tracked_vars])
-  ; if(!identical(dim(tracked_hashes), c(BYTES_PER_TRACKED_HASH*length(tracked_vars), nrow(df)))) 
+  ; if (!identical(dim(tracked_hashes), c(BYTES_PER_TRACKED_HASH * length(tracked_vars), nrow(df)))) 
     return(simpleCondition("Internal error in tracked_vars hash preparation"))
   
   # NOTE: We choose a serialization scheme with a well-known encoding. This avoid security concerns over 
@@ -228,18 +226,18 @@ RS_compute_base_memory <- function(df_id, df, id_vars, tracked_vars){
   return(res)
 }
 
-RS_parse_base <- function(contents){
+RS_parse_base <- function(contents) {
   con <- rawConnection(contents, open = "r")
   file_magic_code <- readBin(con, raw(), 8L) |> rawToChar()
-  ; if(!identical(file_magic_code, "LISTBASE")) return(simpleCondition("Wrong magic code"))
+  ; if (!identical(file_magic_code, "LISTBASE")) return(simpleCondition("Wrong magic code"))
   format_version_number <- readBin(con, raw(), 1L)
-  ; if(!identical(format_version_number, as.raw(0))) return(simpleCondition("Wrong format version number"))
+  ; if (!identical(format_version_number, as.raw(0))) return(simpleCondition("Wrong format version number"))
   generation <- as.integer(readBin(con, raw(), 1L))
-  ; if(!identical(generation, 0L)) return(simpleCondition("Wrong generation marker. Should be 0"))
+  ; if (!identical(generation, 0L)) return(simpleCondition("Wrong generation marker. Should be 0"))
   timestamp <- readBin(con, numeric(), 1L)
   time_delta <- SH$get_UTC_time_in_seconds() - timestamp
-  ; if(time_delta < 0) return(simpleCondition("Timestamp is set in the future"))
-  ; if(time_delta > 2**31) return(simpleCondition("Time delta is set too far in the past"))
+  ; if (time_delta < 0) return(simpleCondition("Timestamp is set in the future"))
+  ; if (time_delta > 2**31) return(simpleCondition("Time delta is set too far in the past"))
   contents_hash <- readBin(con, raw(), 16L)
   domain_string <- SH$read_string_from_con(con)
   id_vars <- SH$read_character_vector_from_con(con)
@@ -249,10 +247,10 @@ RS_parse_base <- function(contents){
   row_count <- readBin(con, integer(), 1L)
  
   id_hashes <- SH$read_hashes_from_con(con, row_count, 16L)
-  tracked_hashes <- SH$read_hashes_from_con(con, row_count, BYTES_PER_TRACKED_HASH*length(tracked_vars))
+  tracked_hashes <- SH$read_hashes_from_con(con, row_count, BYTES_PER_TRACKED_HASH * length(tracked_vars))
   
   empty_read <- readBin(con, raw(), 1L)
-  ; if(length(empty_read) > 0) return(simpleCondition("Too much hash data"))
+  ; if (length(empty_read) > 0) return(simpleCondition("Too much hash data"))
   close(con)
   
   res <- list(
@@ -273,7 +271,7 @@ RS_parse_base <- function(contents){
   return(res)
 }
 
-RS_compute_delta_memory <- function(state, df){
+RS_compute_delta_memory <- function(state, df) {
   checkmate::assert_data_frame(df) # TODO: etc.
   
   error <- character(0)
@@ -287,14 +285,14 @@ RS_compute_delta_memory <- function(state, df){
   tracked_vars <- state$tracked_vars
   # FIXME: (LUIS): Ask Miguel about the postlude
   tracked_hashes <- (SH$hash_tracked(df[tracked_vars]) |> c() |> 
-                       array(dim = c(BYTES_PER_TRACKED_HASH*length(tracked_vars), nrow(df))))
+                       array(dim = c(BYTES_PER_TRACKED_HASH * length(tracked_vars), nrow(df))))
 
   # Assert against removal of rows
   local({
     merged <- cbind(id_hashes, state$id_hashes, deparse.level = 0)
     dropped_row_mask <- !duplicated(merged, MARGIN = 2) |> c() |> tail(n = ncol(state$id_hashes))
     dropped_row_count <- sum(dropped_row_mask)
-    if(dropped_row_count > 0){
+    if (dropped_row_count > 0) {
       error <<- c(error, sprintf("Dataset update is missing %s previously known row(s).\n", dropped_row_count))
     }
   })
@@ -307,7 +305,7 @@ RS_compute_delta_memory <- function(state, df){
   new_tracked_hashes <- tracked_hashes[, new_row_indices, drop = FALSE]
 
   # drop new rows
-  if(length(new_row_indices)){
+  if (length(new_row_indices)) {
     id_hashes <- id_hashes[, -new_row_indices, drop = FALSE]
     tracked_hashes <- tracked_hashes[, -new_row_indices, drop = FALSE]
   }
@@ -322,14 +320,14 @@ RS_compute_delta_memory <- function(state, df){
   tracked_hashes <- tracked_hashes[, mapping, drop = FALSE]
 
   merged <- cbind(state$tracked_hashes, tracked_hashes, deparse.level = 0)
-  modified_row_mask <- !duplicated(merged, MARGIN = 2) |> c() |> tail(n = nrow(df)-length(new_row_indices))
+  modified_row_mask <- !duplicated(merged, MARGIN = 2) |> c() |> tail(n = nrow(df) - length(new_row_indices))
   modified_row_indices <- which(modified_row_mask)
   
   res <- list(
     contents = c(
       charToRaw("LISTDELT"),                                # file magic code
       as.raw(0),                                            # format version number
-      as.raw(state$generation+1L),                          # generation marker
+      as.raw(state$generation + 1L),                        # generation marker
       SH$integer_to_raw(time_delta),                        # delta timestamp (seconds since state)
       df_hash,                                              # complete hash of input data.frame
       SH$string_to_raw(state$domain),                       # domain string
@@ -345,27 +343,27 @@ RS_compute_delta_memory <- function(state, df){
   return(res)
 }
 
-RS_parse_delta <- function(contents, tracked_var_count){
+RS_parse_delta <- function(contents, tracked_var_count) {
   con <- rawConnection(contents, open = "r")
   file_magic_code <- readBin(con, raw(), 8L) |> rawToChar()
-  ; if(!identical(file_magic_code, "LISTDELT")) return(simpleCondition("Wrong magic code"))
+  ; if (!identical(file_magic_code, "LISTDELT")) return(simpleCondition("Wrong magic code"))
   format_version_number <- readBin(con, raw(), 1L)
-  ; if(!identical(format_version_number, as.raw(0))) return(simpleCondition("Wrong format version number"))
+  ; if (!identical(format_version_number, as.raw(0))) return(simpleCondition("Wrong format version number"))
   generation <- as.integer(readBin(con, raw(), 1L))
   time_delta <- readBin(con, integer(), 1L)
-  ; if(time_delta < 0) return(simpleCondition("Negative time delta"))
+  ; if (time_delta < 0) return(simpleCondition("Negative time delta"))
   contents_hash <- readBin(con, raw(), 16L)
   domain <- SH$read_string_from_con(con)
   new_row_count <- readBin(con, integer(), 1L)
   new_id_hashes <- SH$read_hashes_from_con(con, new_row_count, 16L)
-  new_tracked_hashes <- SH$read_hashes_from_con(con, new_row_count, BYTES_PER_TRACKED_HASH*tracked_var_count)
+  new_tracked_hashes <- SH$read_hashes_from_con(con, new_row_count, BYTES_PER_TRACKED_HASH * tracked_var_count)
   modified_row_count <- NA_integer_
   modified_row_indices <- SH$read_integer_vector_from_con(con)
   modified_row_count <- length(modified_row_indices)
-  modified_tracked_hashes <- SH$read_hashes_from_con(con, modified_row_count, BYTES_PER_TRACKED_HASH*tracked_var_count)
+  modified_tracked_hashes <- SH$read_hashes_from_con(con, modified_row_count, BYTES_PER_TRACKED_HASH * tracked_var_count)
 
   empty_read <- readBin(con, raw(), 1L)
-  ; if(length(empty_read) > 0) return(simpleCondition("Too much hash data"))
+  ; if (length(empty_read) > 0) return(simpleCondition("Too much hash data"))
   close(con)
 
   res <- list(
@@ -384,11 +382,11 @@ RS_parse_delta <- function(contents, tracked_var_count){
   return(res)
 }
 
-RS_compute_review_codes_memory <- function(review_codes){
+RS_compute_review_codes_memory <- function(review_codes) {
   checkmate::assert_character(review_codes, min.chars = 1)
   
   pcodes <- raw(0)
-  for(code in review_codes) pcodes <- c(pcodes, SH$string_to_raw(code))
+  for (code in review_codes) pcodes <- c(pcodes, SH$string_to_raw(code))
   
   res <- c(
     charToRaw("LISTCODE"), # file magic code
@@ -399,16 +397,16 @@ RS_compute_review_codes_memory <- function(review_codes){
   return(res)
 }
 
-RS_parse_review_codes <- function(contents){
+RS_parse_review_codes <- function(contents) {
   con <- rawConnection(contents, open = "r")
   file_magic_code <- readBin(con, raw(), 8L) |> rawToChar()
-  ; if(!identical(file_magic_code, "LISTCODE")) return(simpleCondition("Wrong magic code"))
+  ; if (!identical(file_magic_code, "LISTCODE")) return(simpleCondition("Wrong magic code"))
   format_version_number <- readBin(con, raw(), 1L)
-  ; if(!identical(format_version_number, as.raw(0))) return(simpleCondition("Wrong format version number"))
+  ; if (!identical(format_version_number, as.raw(0))) return(simpleCondition("Wrong format version number"))
   
   res <- character(0)
   code <- SH$read_string_from_con(con) 
-  while(!is.null(code)){
+  while (!is.null(code)) {
     res <- c(res, code)
     code <- SH$read_string_from_con(con) 
   }
@@ -418,7 +416,7 @@ RS_parse_review_codes <- function(contents){
   return(res)
 }
 
-RS_compute_review_reviews_memory <- function(role, dataset){
+RS_compute_review_reviews_memory <- function(role, dataset) {
   checkmate::assert_string(role, min.chars = 1)
   
   prole <- SH$string_to_raw(role)
@@ -427,35 +425,35 @@ RS_compute_review_reviews_memory <- function(role, dataset){
     charToRaw("LISTREVI"),     # file magic code
     as.raw(0),                 # format version number
     prole,                     # role string
-    SH$string_to_raw(dataset)  # domain/dataset
+    SH$string_to_raw(dataset)  # domain
   )
   
   return(res)
 }
 
-RS_parse_review_reviews <- function(contents, dataset_to_state_row_mapping, expected_role, expected_domain){
+RS_parse_review_reviews <- function(contents, dataset_to_state_row_mapping, expected_role, expected_domain) {
   row_count <- length(dataset_to_state_row_mapping)
   res <- data.frame(review = rep(0L, row_count), timestamp = rep(0., row_count))
   
   con <- rawConnection(contents, open = "r")
   file_magic_code <- readBin(con, raw(), 8L) |> rawToChar()
-  ; if(!identical(file_magic_code, "LISTREVI")) return(simpleCondition("Wrong magic code"))
+  ; if (!identical(file_magic_code, "LISTREVI")) return(simpleCondition("Wrong magic code"))
   format_version_number <- readBin(con, raw(), 1L)
-  ; if(!identical(format_version_number, as.raw(0))) return(simpleCondition("Wrong format version number"))
+  ; if (!identical(format_version_number, as.raw(0))) return(simpleCondition("Wrong format version number"))
   
   role <- SH$read_string_from_con(con)
-  ; if(!identical(role, expected_role)) return(simpleCondition(sprintf("Expected role `%s`", expected_role)))
+  ; if (!identical(role, expected_role)) return(simpleCondition(sprintf("Expected role `%s`", expected_role)))
   domain <- SH$read_string_from_con(con)
-  ; if(!identical(domain, expected_domain)) return(simpleCondition(sprintf("Expected domain `%s`", expected_domain)))
+  ; if (!identical(domain, expected_domain)) return(simpleCondition(sprintf("Expected domain `%s`", expected_domain)))
   
-  f_cur <- seek(con, where = 0, origin = 'end', rw = 'read')
-  f_end <- seek(con, where = f_cur, origin = 'start', rw = 'read')
+  f_cur <- seek(con, where = 0, origin = "end", rw = "read")
+  f_end <- seek(con, where = f_cur, origin = "start", rw = "read")
   
-  record_count <- (f_end - f_cur)/(4+4+8) # integer+integer+numeric
-  for(i in seq_len(record_count)){
-    row_index <- readBin(con, integer(), 1L, endian = 'little')
-    review <- readBin(con, integer(), 1L, endian = 'little')
-    timestamp <- readBin(con, numeric(), 1L, endian = 'little')
+  record_count <- (f_end - f_cur) / (4 + 4 + 8) # sizes correspond to integer+integer+numeric
+  for (i in seq_len(record_count)){
+    row_index <- readBin(con, integer(), 1L, endian = "little")
+    review <- readBin(con, integer(), 1L, endian = "little")
+    timestamp <- readBin(con, numeric(), 1L, endian = "little")
     # NOTE: timestamp increases monotonically with each new row, so not checking it
     row_index <- dataset_to_state_row_mapping[[row_index]]
     res[["review"]][[row_index]] <- review
@@ -466,17 +464,17 @@ RS_parse_review_reviews <- function(contents, dataset_to_state_row_mapping, expe
   return(res)
 }
 
-RS_load <- function(base, deltas){
+RS_load <- function(base, deltas) {
   res <- RS_parse_base(base) 
   base_timestamp <- res$timestamp
-  for(delta in deltas){
+  for (delta in deltas){
     state_delta <- RS_parse_delta(contents = delta, tracked_var_count = length(res[["tracked_vars"]]))
-    if(inherits(state_delta, "simpleCondition")) return(state_delta)
+    if (inherits(state_delta, "simpleCondition")) return(state_delta)
     
-    if(!identical(state_delta$generation, res$generation+1L))
-      return(simpleCondition(paste("Wrong generation marker. Should be", res$generation+1L)))
+    if (!identical(state_delta$generation, res$generation + 1L))
+      return(simpleCondition(paste("Wrong generation marker. Should be", res$generation + 1L)))
     
-    if(!identical(state_delta$domain, res$domain))
+    if (!identical(state_delta$domain, res$domain))
       return(simpleCondition(paste("Wrong domain. Expected", res$domain, "and got", state_delta$domain)))
    
     res$contents_hash <- state_delta$contents_hash
@@ -485,19 +483,19 @@ RS_load <- function(base, deltas){
     res$row_count <- res$row_count + state_delta$new_row_count
     res$id_hashes <- cbind(res$id_hashes, state_delta$new_id_hashes)
     res$tracked_hashes <- cbind(res$tracked_hashes, state_delta$new_tracked_hashes)
-    res$row_timestamps <- c(res$row_timestamps, rep(base_timestamp+state_delta$time_delta, state_delta$new_row_count))
+    res$row_timestamps <- c(res$row_timestamps, rep(base_timestamp + state_delta$time_delta, state_delta$new_row_count))
     
     # modified rows
-    res$tracked_hashes[,state_delta$modified_row_indices] <- state_delta$modified_tracked_hashes
-    res$row_timestamps[state_delta$modified_row_indices] <- base_timestamp+state_delta$time_delta
+    res$tracked_hashes[, state_delta$modified_row_indices] <- state_delta$modified_tracked_hashes
+    res$row_timestamps[state_delta$modified_row_indices] <- base_timestamp + state_delta$time_delta
   }
   return(res)
 }
 
-RS_append <- function(path, contents){
+RS_append <- function(path, contents) {
   # TODO: Copy file, append to copy, rename back
-  f <- file(path, open = 'r+b', raw = TRUE)
-  seek(f, where = 0, origin = 'end', rw = 'write')
+  f <- file(path, open = "r+b", raw = TRUE)
+  seek(f, where = 0, origin = "end", rw = "write")
   writeBin(contents, f)
   close(f)
 }
@@ -506,18 +504,18 @@ RS_append <- function(path, contents){
 #       They may be useful for performance testing, but maybe a higher-level approach,
 #       such as that on `tests/testthat/test-review.R`, is enough and we don't need
 #       to call the `RS_*` functions directly.
-if(FALSE){
-  describe_and_time <- function(description, expr){
+if (FALSE) {
+  describe_and_time <- function(description, expr) {
     t0 <- Sys.time()
     res <- force(expr)
     t1 <- Sys.time()
-    cat(sprintf("%.2f s: %s\n", t1-t0, description))
-    if(inherits(res, "condition")) stop(res)
+    cat(sprintf("%.2f s: %s\n", t1 - t0, description))
+    if (inherits(res, "condition")) stop(res)
     return(res)
   }
  
-  if(FALSE) {
-    df <- safetyData::adam_adae[1:2,]
+  if (FALSE) {
+    df <- safetyData::adam_adae[1:2, ]
     base_contents <- describe_and_time(
       "Derive .base file contents from initial dataset (expensive; only done the first time app is run by some user)", {
         df_id <- "ae"
@@ -532,7 +530,7 @@ if(FALSE){
       RS_load(base_contents, deltas = list())
     )
     
-    df <- safetyData::adam_adae[2:1,] # Reverse the order of rows of the dataset
+    df <- safetyData::adam_adae[2:1, ] # Reverse the order of rows of the dataset
     
     delta1_contents <- describe_and_time(
       "Processing dataset update (done first time app is run after update)",
@@ -544,7 +542,7 @@ if(FALSE){
       RS_load(base_contents, deltas = list(delta1_contents)) 
     )
     
-    df[1,][["AESEV"]] <- 'SEVERE'
+    df[1, ][["AESEV"]] <- "SEVERE"
     delta2_contents <- describe_and_time(
       "Processing dataset update (done first time app is run after update)",
       RS_compute_delta_memory(review_state, df)[["contents"]]
@@ -557,15 +555,15 @@ if(FALSE){
 
   # Build an arbitrarily large input dataset
   df <- local({
-    df <- safetyData::adam_adae[1:1000,]
-    df <- rbind(df, df, df, df, df, df, df, df, df, df) # 10k
-    # df <- rbind(df, df, df, df, df, df, df, df, df, df) # 100k
-    # df <- rbind(df, df, df, df, df, df, df, df, df, df) # 1000k
+    df <- safetyData::adam_adae[1:1000, ]
+    df <- rbind(df, df, df, df, df, df, df, df, df, df) # 10k # nolint
+    # df <- rbind(df, df, df, df, df, df, df, df, df, df) # 100k # nolint
+    # df <- rbind(df, df, df, df, df, df, df, df, df, df) # 1000k # nolint
     
-    for(i_row_block in seq_len(nrow(df)/1000)){
+    for (i_row_block in seq_len(nrow(df) / 1000)){
       fake_study_prefix <- sprintf("%05d", i_row_block)
-      df[["USUBJID"]][seq((i_row_block-1)*1000 + 1, i_row_block*1000)] <- 
-        sub('^01', fake_study_prefix, df[["USUBJID"]][seq((i_row_block-1)*1000 + 1, i_row_block*1000)])
+      df[["USUBJID"]][seq((i_row_block - 1) * 1000 + 1, i_row_block * 1000)] <- 
+        sub("^01", fake_study_prefix, df[["USUBJID"]][seq((i_row_block - 1) * 1000 + 1, i_row_block * 1000)])
     }
     return(df)
   })
@@ -586,14 +584,14 @@ if(FALSE){
     c("Seen", "Should look into", "Looked into", "We don't seem to agree", "Clearly artifactual")
   )
   
-  if(FALSE){
+  if (FALSE) {
     review_codes <- RS_parse_review_codes(review_codes_raw)
     
-    browser() # TODO: RS_compute_role_review_memory + RS_parse_role_review
+    browser() # TODO: Maybe RS_compute_role_review_memory + RS_parse_role_review
     
     review_roles <- c("TSTAT", "SP", "Safety", "CTL")
     
-    for(role in review_roles){
+    for (role in review_roles) {
       browser()
       
     }
@@ -605,9 +603,9 @@ if(FALSE){
   )
 
   # Let's imagine there is an update that adds a new entry to the dataset
-  df <- rbind(df, safetyData::adam_adae[1001,])
+  df <- rbind(df, safetyData::adam_adae[1001, ])
   # Furthermore, the severity of an adverse event is described now as "MODERATE" instead of "MILD"
-  df[500, 'AESEV'] <- 'MODERATE'
+  df[500, "AESEV"] <- "MODERATE"
   
   delta1_contents <- describe_and_time(
     "Processing dataset update (done first time app is run after update)",
@@ -620,11 +618,11 @@ if(FALSE){
   )
   
   # The severity of an adverse event is described now as "SEVERE" instead of "MODERATE"
-  df[500, 'AESEV'] <- 'SEVERE'
+  df[500, "AESEV"] <- "SEVERE"
   # and another one that was "MILD" is now "MODERATE"
-  df[501, 'AESEV'] <- 'SEVERE'
+  df[501, "AESEV"] <- "SEVERE"
   # And we also _prepend_ two new entries to the dataset
-  df <- rbind(safetyData::adam_adae[1002:1003,], df)
+  df <- rbind(safetyData::adam_adae[1002:1003, ], df)
   delta2_contents <- describe_and_time(
     "Processing dataset update (done first time app is run after update)",
     RS_compute_delta_memory(review_state, df)[["contents"]]
@@ -637,6 +635,3 @@ if(FALSE){
   
   browser() # TODO: Start the application based on base and deltas (RS_parse_base_and_deltas)
 }
-
-# nolint end
-

--- a/R/review_structures.R
+++ b/R/review_structures.R
@@ -502,9 +502,10 @@ RS_append <- function(path, contents){
   close(f)
 }
 
-# NOTE: The contents of the following conditional are a WIP of the annotation feature.
-#       They are parked until user requirements and technical blockers are clarified.
-# TODO? Repurpose as test/performance test/"live documentation"
+# NOTE: The contents of the following conditional are a WIP of the review feature.
+#       They may be useful for performance testing, but maybe a higher-level approach,
+#       such as that on `tests/testthat/test-review.R`, is enough and we don't need
+#       to call the `RS_*` functions directly.
 if(FALSE){
   describe_and_time <- function(description, expr){
     t0 <- Sys.time()

--- a/man/listings_UI.Rd
+++ b/man/listings_UI.Rd
@@ -52,6 +52,11 @@ Column corresponding to subject ID. Default value is 'USUBJID'}
 
 Function to invoke when a subject ID is clicked in a listing}
 
+\item{review}{\verb{[list()]}
+
+Configuration of the experimental data review feature.
+For more details, please refer to \code{vignette("data_review")}.}
+
 \item{receiver_id}{\verb{[character(1) | NULL]}
 
 Character string defining the ID of the module to which to send a subject ID. The

--- a/man/mod_listings.Rd
+++ b/man/mod_listings.Rd
@@ -43,6 +43,11 @@ Column corresponding to subject ID. Default value is 'USUBJID'}
 
 Character string defining the ID of the module to which to send a subject ID. The
 module must exist in the module list. The default is NULL which disables communication.}
+
+\item{review}{\verb{[list()]}
+
+Configuration of the experimental data review feature.
+For more details, please refer to \code{vignette("data_review")}.}
 }
 \description{
 This module will present the dataset as listing using the DT package.

--- a/tests/testthat/test-hash_tracked.R
+++ b/tests/testthat/test-hash_tracked.R
@@ -1,13 +1,8 @@
 test_that("SH$hash_tracked exhibits almost no false negatives and few false positives", {
-  hash_df <- function(df, tracked_vars) {
-    hashes <- SH$hash_tracked(df[tracked_vars])
-    return(hashes)
-  }
- 
   # TODO(miguel): Refactor and move next to hash_tracked into SH  
   report_changes <- function(df, h0, verbose = FALSE){
     res <- list()
-    h1 <- hash_df(df, tracked_vars = colnames(df))
+    h1 <- SH$hash_tracked(df[colnames(df)])
     
     offsets <- c(0, 2, 3)
     
@@ -17,6 +12,7 @@ test_that("SH$hash_tracked exhibits almost no false negatives and few false posi
       prev <- as.integer(h0[,i_row])
       cur <- as.integer(h1[,i_row])
       diff <- (prev != cur)
+      diff <- apply(matrix(diff, ncol = BYTES_PER_TRACKED_HASH, byrow = TRUE), 1, any)
       evidence <- integer(n_col)
       for(i in seq_len(n_col)){
         v <- diff[[i]]
@@ -56,7 +52,7 @@ test_that("SH$hash_tracked exhibits almost no false negatives and few false posi
   }
   
   stress <- function(df, test_count, changes_per_test){
-    hashes <- hash_df(df, tracked_vars = colnames(df))
+    hashes <- SH$hash_tracked(df[colnames(df)])
     
     n_row <- nrow(df)
     n_col <- ncol(df)
@@ -116,7 +112,7 @@ test_that("SH$hash_tracked exhibits almost no false negatives and few false posi
           false_negatives <- append(false_negatives, tail)
         }
         if(i_rep <= length(reported_changes)) {
-          if(length(false_positives) == 0)  false_positive_first_delta <- expected_changes
+          if(length(false_positives) == 0) false_positive_first_delta <- expected_changes
           tail <- reported_changes[i_rep:length(reported_changes)]
           false_positives <- append(false_positives, tail)
         }

--- a/tests/testthat/test-review.R
+++ b/tests/testthat/test-review.R
@@ -1,0 +1,57 @@
+local({
+  folder_contents <- NULL
+  fs_callbacks <- list(
+    attach = function(arg) NULL, list = function(arg) NULL, read = function(arg) NULL, write = function(arg) NULL,
+    append = function(arg) NULL, execute_IO_plan = function(arg) NULL,
+    read_folder = function(arg) folder_contents <<- arg
+  )
+  
+  store_path <- file.path(tempdir(), "data_checks")
+  dir.create(store_path)
+  on.exit(unlink(store_path, recursive = TRUE), add = TRUE, after = FALSE)
+  
+  fs_client <- fs_init(callbacks = fs_callbacks, store_path)
+  fs_client[["read_folder"]](subfolder_candidates = "dataset_list")
+  
+  # Review folder contents is initialized here
+  review = list(
+    datasets = list(
+      ae = list(
+        id_vars = c("USUBJID", "AESEQ"), 
+        tracked_vars = c(
+          "AESEV", "AETERM", "AEHLGT", "AEHLT", "AELLT", 
+          "AEDECOD", "AESOC", "AESTDTC", "AEENDTC", "AESTDY","AEOUT", "AEACN", "AEREL"
+        )
+      )
+    ),
+    choices = c("choiceA", "choiceB"),
+    roles = c("roleA", "roleB")
+  )
+  
+  dataset_lists <- list(
+    dataset_list = list(
+      ae = safetyData::sdtm_ae[1:2,]
+    )
+  )
+  
+  info <- REV_load_annotation_info(folder_contents, review, dataset_lists)
+  expect_length(info[["error"]], 0)
+  fs_client[["execute_IO_plan"]](IO_plan = info[["folder_IO_plan"]], is_init = TRUE)
+  fs_client[["read_folder"]](subfolder_candidates = "dataset_list")
+  
+  test_that("Detect modification of previously known row and output new delta file", {
+    dataset_lists2 <- dataset_lists
+    dataset_lists2[["dataset_list"]][["ae"]][["AESEV"]][[1]] <- "SEVERE"
+    
+    info <- REV_load_annotation_info(folder_contents, review, dataset_lists2)
+    expect_length(info[["error"]], 0)
+    expect_length(info[["folder_IO_plan"]], 1)
+    folder_op <- info[["folder_IO_plan"]][[1]]
+    expect_equal(folder_op[["type"]], "write_file")
+    expect_equal(folder_op[["fname"]], "ae_001.delta")
+    
+    delta <- RS_parse_delta(info[["folder_IO_plan"]][[1]][["contents"]], 13)
+    
+    expect_equal(delta[["modified_row_indices"]], c(1L))
+  })
+})

--- a/vignettes/data_review.Rmd
+++ b/vignettes/data_review.Rmd
@@ -146,7 +146,7 @@ If we take a hypothetical "xyz" domain, `dv.listings` will store the following f
 - m `tracked_vars` variable types (see "Variable type encoding" below)
 - 1 row count
 - p (1 per "xyz" row) `hash_id(xyz[id_vars])`
-- p (1 per "xyz" row, *m* bytes long) `hash_tracked(xyz[tracked_vars])`
+- p (1 per "xyz" row, 2\*m bytes long) `hash_tracked(xyz[tracked_vars])`
 </details>
 
 <details><summary>`xyz_001.delta` (one per domain dataset update)</summary>
@@ -158,10 +158,10 @@ If we take a hypothetical "xyz" domain, `dv.listings` will store the following f
 - 1 domain string ("xyz")
 - 1 count of new rows
 - n (1 per *new* "xyz" row) `hash_id(xyz[id_vars])`
-- n (1 per *new* "xyz" row, *m* bytes long) `hash_tracked(xyz[tracked_vars])`
+- n (1 per *new* "xyz" row, 2\*m bytes long) `hash_tracked(xyz[tracked_vars])`
 - 1 count of modified rows
 - p (1 per *modified* "xyz" row) row index
-- p (1 per *modified* "xyz" row, *m* bytes long) `hash_tracked(xyz[tracked_vars])`
+- p (1 per *modified* "xyz" row, 2\*m bytes long) `hash_tracked(xyz[tracked_vars])`
 </details>
 
 <details><summary>`xyz_<ROLE>.review` (one per domain and ROLE)</summary>
@@ -180,7 +180,7 @@ If we take a hypothetical "xyz" domain, `dv.listings` will store the following f
 
 (Row indices refer to indices in the stored base+delta matrix, which is append-only. These _canonical_ indices are as good as identifiers).
 
-The dominant factor governing the size of these files is the length of a hash, which is 16 bytes, as we discuss in the "Hashing" session below. Row indices and delta timestamps can be encoded in 4 bytes. Review indices take up 1 byte each. Estimating an upper bound of 1 million rows per dataset, a `.base` file would take around 32 MiB. A comprehensive `.review` file for such a dataset would take around 9 MiB.
+The dominant factor governing the size of these files is the length of a hash, which is 16 bytes in the case of `hash_id` and 2\*m bytes (m being the number of tracked columns) in the case of `hash_tracked`, as we discuss in the "Hashing" session below. Row indices and delta timestamps can be encoded in 4 bytes. Review indices take up 1 byte each. Estimating an upper bound of 1 million rows per dataset, a `.base` file tracking 8 variables would take around 32 MiB. A comprehensive `.review` file for such a dataset would take around 9 MiB.
 
 These file structures are designed so that they start with a short heterogeneous header that reiterates the information that can be gleaned from the file name. The rest of the records are all homogeneous and of known size. That allows to load them into memory without the need for expensive parsing.
 
@@ -232,36 +232,36 @@ We opt instead for 128 bits, which makes the possibility of a collision extremel
 #### Hashing of tracked variables (`hash_tracked()`)
 We could apply the same reasoning behind the choice of the `hash_id()` function to the hashing of the variable parts of each row. We instead propose a more complex hashing scheme to provide partial information about *which variables of a row have been altered* when its hash changes.
 
-Each hash value is *m* bytes long, where *m* is the number of variables tracked of a given dataset. Each of those bytes is an independent hash of three of the tracked variables of a dataset row. Each variable, in turn, contributes to three of the *m* byte-sized hashes. This mixing of variables makes it harder for an external adversarial observer of the `.base` and `.delta` files to brute-force the original values of the dataset by looking for collisions with the computed hash values.
+Each hash value is 2\*m bytes long, where *m* is the number of variables tracked of a given dataset. Each of those bytes is an independent hash of three of the tracked variables of a dataset row. Each variable, in turn, contributes to three of the 2\*m byte-sized hashes. This mixing of variables makes it harder for an external adversarial observer of the `.base` and `.delta` files to brute-force the original values of the dataset by looking for collisions with the computed hash values.
 
-To compute which variables contribute to which hash byte, we use the following scheme:
+To compute which variables contribute to which hash byte pair, we use the following scheme:
 
-  - Byte *n*: Variables (*n*+0)%*n*, (*n*+2)%*n* and (*n*+3)%*n*
+  - Byte pair *n*: Variables (*n*+0)%*n*, (*n*+2)%*n* and (*n*+3)%*n*
 
 Where `%` indicates the remainder of the integer division.
 
 So, for a input dataset with seven tracked variables (zero through six), this would mean:
 
-  - Byte 0: Variables 0, 2 and 3
-  - Byte 1: Variables 1, 3 and 4
-  - Byte 2: Variables 2, 4 and 5
-  - Byte 3: Variables 3, 5 and 6
-  - Byte 4: Variables 4, 6 and 0
-  - Byte 5: Variables 5, 0 and 1
-  - Byte 6: Variables 6, 1 and 2
+  - Byte pair 0: Variables 0, 2 and 3
+  - Byte pair 1: Variables 1, 3 and 4
+  - Byte pair 2: Variables 2, 4 and 5
+  - Byte pair 3: Variables 3, 5 and 6
+  - Byte pair 4: Variables 4, 6 and 0
+  - Byte pair 5: Variables 5, 0 and 1
+  - Byte pair 6: Variables 6, 1 and 2
 
-This scheme creates a unique mixtures of variables. Take, for instance, variable 0. It is combined with variables 2 and 3 on the zeroth byte, with variables 4 and 6 on the fourth byte and with 1 and 5 for the fifth byte.
+This scheme creates a unique mixtures of variables. Take, for instance, variable 0. It is combined with variables 2 and 3 on the zeroth byte pair, with variables 4 and 6 on the fourth byte pair and with 1 and 5 for the fifth byte pair.
 
-Each of these bytes is computed by:
+Each of these byte pairs is computed by:
 
 - Taking the three values to hash.
 - Serializing them to text and concatenating them using the non-ASCII byte separator `1D` (also known as "group separator").
-- Computing the `xxh32` hash and returning its most significant byte.
+- Computing the `xxh32` hash and returning its two most significant bytes.
 
 Informal testing (refer to `tests/testthat/tests-hash_tracked.R` for more details) of this hashing scheme shows the following properties:
 
 - It's capable of identifying up to four modified variables per row (after that, it's preferable to give up and notify the whole row as modified).
-- It has a very low **false negative rate** (a variable is modified without it being notified as such) of one for every 8 million row updates.
+- It has a very low **false negative rate** (a variable is modified without it being notified as such).
 - It has a low **false positive rate** (a variable that retains its value is notified as modified). This only happens when there are actual changes to a row.
 
 False positives are not critical, as they ask reviewers to consider a larger set of variables when re-reviewing a row that has been altered.

--- a/vignettes/data_review.Rmd
+++ b/vignettes/data_review.Rmd
@@ -78,7 +78,7 @@ The `review` parameter is itself divided into four subfields:
   - `id_vars`: `[character(n)]` Immutable variables that uniquely identify each record for a given domain. For example, in the case of the demographics domain, the **U**nique **SUBJ**ect **ID**entifier is enough. In the case of the adverse events domain, both USUBJID and the **A**dverse **E**vent **SEQ**uence number are necessary.
   - `tracked_vars`: `[character(3+)]` Variables to track across dataset updates. If the contents of one of this columns changes on an already reviewed row, that review will be marked as potentially outdated. This vector should list at least three variables.
 - `choices`: `[character(n)]` Review choices available to assign to each listing row.
-- `roles`: `[character(n)]` Names of reviewer roles.
+- `roles`: `[character(n)]` Names of reviewer roles. These names can only include the following characters: alphanumerical, space, dot, underscore and dash.
 - `store_path`: `[character(1)]` Optional. If specified, files associated to the review process will be stored on this path on the server. If left unspecified, those files will be stored on a folder of the _client_'s computer. The users of the app will have the opportunity to choose the path when they launch it.
 
 ## Storage of review-related files

--- a/vignettes/data_review.Rmd
+++ b/vignettes/data_review.Rmd
@@ -1,8 +1,8 @@
 ---
-title: "Data review"
+title: "Data review (experimental feature)"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{Data review}
+  %\VignetteIndexEntry{Data review (experimental feature)}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---


### PR DESCRIPTION
As discussed during a prior PR review, the module now devotes one extra byte for each tracked domain variable. This should make the chances of a tracked hash collision infinitesimal.