### PR TITLE
Prevent DT scrolling back to the top of the table after mouse interaction + data reload.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: dv.listings
 Type: Package
 Title: Data listings module
-Version: 4.2.0-9000
+Version: 4.2.0-9001
 Authors@R: 
     c(
       person("Boehringer-Ingelheim Pharma GmbH & Co.KG", role = c("cph", "fnd")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# dv.listings 4.2.0-9000
+# dv.listings 4.2.0-9001
 - Bulk editing of reviews
 - Highlighting of modified columns for outdated reviews
 

--- a/R/mod_listings.R
+++ b/R/mod_listings.R
@@ -98,7 +98,7 @@ listings_UI <- function(module_id) { # nolint
       shiny::tags[["button"]](
         id = ns(TBL$RESET_ROWS_ORDER_BUTTON_ID),
         class = "btn btn-default action-button",
-        "Reset Row Order"
+        TBL$RESET_ROWS_ORDER_BUTTON_LABEL
       ),
       shiny::tags[["script"]](shiny::HTML(sprintf("
   $(document).on('click', '#%s', function() {

--- a/inst/www/js/dv_listings.js
+++ b/inst/www/js/dv_listings.js
@@ -108,7 +108,7 @@ const dv_listings = (function () {
         let result = '<div style="display: flex; align-items: baseline; gap: 0.5rem;">';
         result += `<input type="checkbox" data-for-row="${row[row_number_idx]}" data-input-type="bulk-control" onchange = "dv_listings.on_change_table_checkbox(event)">`;
         let options = choices;
-        result += `<select onchange=\"Shiny.setInputValue('${id}', {row:${row[row_number_idx]}, option:this.value, bulk:'false'}, {priority: 'event'});\">`;
+        result += `<select onmousedown=\"event.preventDefault(); event.srcElement.showPicker();\" onchange=\"Shiny.setInputValue('${id}', {row:${row[row_number_idx]}, option:this.value, bulk:'false'}, {priority: 'event'});\">`;
         for (let i = 0; i < options.length; i += 1) {
           result += `<option value=${i + 1}${options[i] == data ? ' selected' : ''}>${options[i]}</option>`;
         }
@@ -144,12 +144,12 @@ const dv_listings = (function () {
         <div style="width: 100px">
         <div class = "label ${label_class}"> ${data} </div>
         <div>
-        <button class = "btn btn-primary btn-xs" style=\"width:100%%\" onclick=\"dv_listings.show_child(event, this, '${meta.settings}')\" title="Show detailed review info">\u{1F4CB}</button>
+        <button class = "btn btn-primary btn-xs" style=\"width:100%%\" onmousedown=\"event.preventDefault();\" onclick=\"dv_listings.show_child(event, this, '${meta.settings}')\" title="Show detailed review info">\u{1F4CB}</button>
         `;
 
         if (add_confirm_button) {
           result += `
-          <button class = "btn btn-primary btn-xs" style=\"width:100%%\" onclick=\"Shiny.setInputValue('${id}', {row:${row[row_number_idx]}, option:'${options.indexOf(row[latest_review_idx]) + 1}', bulk:'false'}, {priority: 'event'})\" title="Agree with latest review">\u2714</button>          
+          <button class = "btn btn-primary btn-xs" style=\"width:100%%\" onmousedown=\"event.preventDefault();\" onclick=\"Shiny.setInputValue('${id}', {row:${row[row_number_idx]}, option:'${options.indexOf(row[latest_review_idx]) + 1}', bulk:'false'}, {priority: 'event'})\" title="Agree with latest review">\u2714</button>          
           `
         }
         result += `</div></div>`

--- a/vignettes/data_review.Rmd
+++ b/vignettes/data_review.Rmd
@@ -253,7 +253,7 @@ So, for a input dataset with seven tracked variables (zero through six), this wo
   - Byte pair 5: Variables 5, 0 and 1
   - Byte pair 6: Variables 6, 1 and 2
 
-This scheme creates a unique mixtures of variables. Take, for instance, variable 0. It is combined with variables 2 and 3 on the zeroth byte pair, with variables 4 and 6 on the fourth byte pair and with 1 and 5 for the fifth byte pair.
+This scheme creates unique mixtures of variables. Take, for instance, variable 0. It is combined with variables 2 and 3 on the zeroth byte pair, with variables 4 and 6 on the fourth byte pair and with 1 and 5 for the fifth byte pair.
 
 Each of these byte pairs is computed by:
 


### PR DESCRIPTION
(Doc and screenshots are not yet included as this version will not reach users yet.)

(The proposed solution works, but I'm still scratching my head on this one).

The problem is that after **reviewing data with the controls embedded in the table, the table scrolls back to the beginning**. This is a big ergonomic failure.

Now, _crucially_, this **doesn't happen when using the bulk review controls**, even if only for a single row. It doesn't happen either when the code in the `onclick` handler of either the single-row or bulk review controls is executed in the browser's javascript console.

And, to makes matters more confusing, if you:
- click on one of the embedded selector dropdowns
- click away _without changing the selection_
- and then trigger the `onclick` handler from the javascript console
the table _DOES_ scroll back to the top.

So, there is _something_ in the table that remembers that there was a click. After that, when there is a `DT::replaceData` that in turn calls an `ajax.reload()` in the browser, the scroll position goes back to the top.

The approach I've taken is to **silence the default actions of the three embedded input elements** that we have on the table. The default action for the select dropdown is to... well... drop down, so I've restored that one manually.

I've tested the fixed behavior on both chromium and on an oldish firefox. It works nicely.
Safari has experimental macOs support for [select.showPicker()](https://developer.mozilla.org/en-US/docs/Web/API/HTMLSelectElement/showPicker#browser_compatibility), but it's not supported on iOS. I'm not sure we care.

I _would_ prefer this option over saving and restoring the `scrollTop` position if I understood why it works. But since I don't, I'm open to the alternative.

