### PR TITLE
Adapt logic to work again with filtered dataset.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: dv.listings
 Type: Package
 Title: Data listings module
-Version: 4.3.3
+Version: 4.3.3-9000
 Authors@R: 
     c(
       person("Boehringer-Ingelheim Pharma GmbH & Co.KG", role = c("cph", "fnd")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# dv.listings 4.3.3-9000
+- Review functionality:
+  - Fix regression when global filter is active
+
 # dv.listings 4.3.3
 - Review functionality:
   - Guard against the removal of known rows and provide parameter to disable this check

--- a/R/mod_listings.R
+++ b/R/mod_listings.R
@@ -577,35 +577,9 @@ listings_server <- function(module_id,
         # NOTE: Partially repeats #weilae 
         annotation_info <- REV_state[["annotation_info"]][[selected_dataset_list_name]][[selected_dataset_name]]
         
-        if (nrow(table_data[["data"]]) < nrow(annotation_info)) { # subset `annotation_info` to match data filter
-          annotation_info <- local({
-            res <- annotation_info
-            filter_mask <- attr(table_data[["data"]], "filter_mask")
-            
-            # filter data rows
-            res <- res[filter_mask, ]
-            
-            # filter latest_reviews
-            latest_reviews <- attr(res, "latest_reviews")
-            for (i in seq_along(latest_reviews)){ 
-              latest_reviews[[i]][["review"]] <- latest_reviews[[i]][["review"]][filter_mask]
-              latest_reviews[[i]][["timestamp"]] <- latest_reviews[[i]][["timestamp"]][filter_mask]
-            }
-            attr(res, "latest_reviews") <- latest_reviews
-          
-            # filter revisions 
-            revisions <- attr(res, "revisions")
-            tracked_hashes <- revisions[["tracked_hashes"]]
-            for (i in seq_along(tracked_hashes)){
-              h <- tracked_hashes[[i]]
-              h <- h[, filter_mask, drop = FALSE]
-              tracked_hashes[[i]] <- h
-            }
-            revisions[["tracked_hashes"]] <- tracked_hashes
-            attr(res, "revisions") <- revisions
-            
-            return(res)
-          })
+        filter_mask <- attr(table_data[["data"]], "filter_mask")
+        if (!all(filter_mask)) { # subset `annotation_info` to match data filter
+          annotation_info <- REV_filter_annotation_info(annotation_info, filter_mask)
         } 
         
         changes <- REV_include_review_info(

--- a/R/mod_listings.R
+++ b/R/mod_listings.R
@@ -511,6 +511,7 @@ listings_server <- function(module_id,
       }
      
       # NOTE: Pass the reconstructed `filter_mask` as an attribute of `data` itself to ensure they're synchronized
+      # TODO: Take the filter_mask from dv.manager 3.x.x instead
       if (enable_review) {
         attr(data, "filter_mask") <- local({
           selected_dataset_list_name <- review[["selected_dataset"]]()
@@ -575,6 +576,38 @@ listings_server <- function(module_id,
 
         # NOTE: Partially repeats #weilae 
         annotation_info <- REV_state[["annotation_info"]][[selected_dataset_list_name]][[selected_dataset_name]]
+        
+        if (nrow(table_data[["data"]]) < nrow(annotation_info)) { # subset `annotation_info` to match data filter
+          annotation_info <- local({
+            res <- annotation_info
+            filter_mask <- attr(table_data[["data"]], "filter_mask")
+            
+            # filter data rows
+            res <- res[filter_mask, ]
+            
+            # filter latest_reviews
+            latest_reviews <- attr(res, "latest_reviews")
+            for (i in seq_along(latest_reviews)){ 
+              latest_reviews[[i]][["review"]] <- latest_reviews[[i]][["review"]][filter_mask]
+              latest_reviews[[i]][["timestamp"]] <- latest_reviews[[i]][["timestamp"]][filter_mask]
+            }
+            attr(res, "latest_reviews") <- latest_reviews
+          
+            # filter revisions 
+            revisions <- attr(res, "revisions")
+            tracked_hashes <- revisions[["tracked_hashes"]]
+            for (i in seq_along(tracked_hashes)){
+              h <- tracked_hashes[[i]]
+              h <- h[, filter_mask, drop = FALSE]
+              tracked_hashes[[i]] <- h
+            }
+            revisions[["tracked_hashes"]] <- tracked_hashes
+            attr(res, "revisions") <- revisions
+            
+            return(res)
+          })
+        } 
+        
         changes <- REV_include_review_info(
           annotation_info = annotation_info,
           data = table_data[["data"]],
@@ -582,14 +615,17 @@ listings_server <- function(module_id,
         )
         shiny::validate(shiny::need(!inherits(changes, "simpleCondition"), changes[["message"]]))
         
-        latest_reviews <- attr(changes[["data"]], "latest_reviews")
-        data_timestamps <- attr(changes[["data"]], "data_timestamps")
-
         changes[["data"]][[REV$ID$STATUS_COL]] <- REV_compute_status(
-          changes[["data"]], role, latest_reviews, data_timestamps
+          dataset_review = changes[["data"]], 
+          role = role, 
+          latest_reviews_by_role = attr(annotation_info, "latest_reviews"), 
+          data_timestamps = annotation_info[["data_timestamps"]]
         )
         
-        changes[["data"]][[REV$ID$LATEST_REVIEW_COL]] <- REV_review_var_to_json(latest_reviews, data_timestamps)
+        changes[["data"]][[REV$ID$LATEST_REVIEW_COL]] <- REV_review_var_to_json(
+          latest_reviews = attr(annotation_info, "latest_reviews"), 
+          data_timestamps = annotation_info[["data_timestamps"]]
+        )
         changes[["data"]] <- relocate_column(changes[["data"]], REV$ID$LATEST_REVIEW_COL, 4L)
         
         review_col_count <- ncol(changes[["data"]]) - ncol(table_data[["data"]])

--- a/R/review.R
+++ b/R/review.R
@@ -57,6 +57,34 @@ REV_time_from_timestamp <- function(v) {
   return(res)
 }
 
+REV_filter_annotation_info <- function(info, mask) {
+  res <- info 
+
+  # filter data rows
+  res <- res[mask, ]
+
+  # filter latest_reviews
+  latest_reviews <- attr(res, "latest_reviews")
+  for (i in seq_along(latest_reviews)){ 
+    latest_reviews[[i]][["review"]] <- latest_reviews[[i]][["review"]][mask]
+    latest_reviews[[i]][["timestamp"]] <- latest_reviews[[i]][["timestamp"]][mask]
+  }
+  attr(res, "latest_reviews") <- latest_reviews
+
+  # filter revisions 
+  revisions <- attr(res, "revisions")
+  tracked_hashes <- revisions[["tracked_hashes"]]
+  for (i in seq_along(tracked_hashes)){
+    h <- tracked_hashes[[i]]
+    h <- h[, mask, drop = FALSE]
+    tracked_hashes[[i]] <- h
+  }
+  revisions[["tracked_hashes"]] <- tracked_hashes
+  attr(res, "revisions") <- revisions
+
+  return(res)
+}
+
 # Prepends review columns to those of the `data` table
 # Prepends review column names to `col_names`
 REV_include_review_info <- function(annotation_info, data, col_names) {
@@ -862,71 +890,95 @@ REV_respond_to_user_review <- function(ns, state, input, review, selected_datase
     dataset_list_name <- selected_dataset_list_name() 
     dataset_name <- selected_dataset_name()
     
-    unfiltered_data <- review[["data"]][[dataset_list_name]][[dataset_name]]
-    
-    info <- input[[REV$ID$REVIEW_SELECT]]
-
-    # Replace in full bulk operation
-    if ("bulk" %in% names(info) && identical(info[["bulk"]], "filtered")) {
-      info[["row"]] <- input[[paste0(TBL$TABLE_ID, "_rows_all")]]
-    }
-    shiny::req(length(info[["row"]]) > 0)
-    
-    if (length(info[["row"]]) >= REV$CONSTANT$MULTIPLE_REVIEW_THRESHOLD) {
-      REV_show_blocker(ns(TBL$TABLE_ID), message = paste(REV$MESSAGE$MULTIPLE_REVIEW))
-      on.exit(REV_hide_blocker(ns(TBL$TABLE_ID)))
-    }
-    
-    annotation_info <- state[["annotation_info"]][[dataset_list_name]][[dataset_name]]
-    changes <- REV_include_review_info(annotation_info = annotation_info, data = unfiltered_data, col_names = list())
-    if (inherits(changes, "simpleCondition")) {
-      shiny::showNotification(changes[["message"]], type = "warning")
-      warning(changes[["message"]])
-      shiny::req(FALSE)
-    }
-    
-    new_data <- changes[["data"]]
-    timestamp <- SH$get_UTC_time_in_seconds()
-    choice_index <- as.integer(info[["option"]])
-    
-    defiltered_row_indices <- local({
-      row_indices <- as.integer(info[["row"]]) # relative to the filtered data sent to the client
-      filter_mask <- attr(data(), "filter_mask")
-      res <- which(filter_mask)[row_indices]
-      return(res)
-    })
-    
-    changes <- REV_compute_review_changes(
-      data = new_data, row_indices = defiltered_row_indices, annotation_info = annotation_info, 
-      choices = review[["choices"]], choice_index = choice_index,  role = role, 
-      timestamp = timestamp, dataset_list_name = dataset_list_name, dataset_name = dataset_name
-    )
-    
-    new_data <- changes[["data"]]
-    annotation_info <- changes[["annotation_info"]]
-    # IMPORTANT: overwrites global state; it has to be the _unfiltered_ annotation_info!
-    state[["annotation_info"]][[dataset_list_name]][[dataset_name]] <- annotation_info
-    IO_plan <- changes[["IO_plan"]]
-    
-    latest_reviews <- attr(annotation_info, "latest_reviews")
-    data_timestamps <- annotation_info[["data_timestamps"]]
-
-    new_data[[REV$ID$STATUS_COL]] <- REV_compute_status(new_data, role, latest_reviews, data_timestamps)
-    new_data[[REV$ID$LATEST_REVIEW_COL]] <- REV_review_var_to_json(latest_reviews, data_timestamps)
-    new_data <- relocate_column(new_data, REV$ID$LATEST_REVIEW_COL, 4L)
-
-    new_data <- local({
-      # TODO: rewrite REV_include_highlight_info to avoid this clumsy wrapper
-      table_data <- list(data = new_data, col_names = character(0))
-      table_data <- REV_include_highlight_info(
-        table_data, annotation_info, 
-        tracked_vars = review[["datasets"]][[dataset_name]][["tracked_vars"]]
+    # NOTE: This local computes updates to the state of the app (annotation_info, IO_plan), independent from rendering
+    changes_based_on_unfiltered_data <- local({
+      unfiltered_data <- review[["data"]][[dataset_list_name]][[dataset_name]]
+      
+      info <- input[[REV$ID$REVIEW_SELECT]]
+      
+      # Replace in full bulk operation
+      if ("bulk" %in% names(info) && identical(info[["bulk"]], "filtered")) {
+        info[["row"]] <- input[[paste0(TBL$TABLE_ID, "_rows_all")]]
+      }
+      shiny::req(length(info[["row"]]) > 0)
+      
+      if (length(info[["row"]]) >= REV$CONSTANT$MULTIPLE_REVIEW_THRESHOLD) {
+        REV_show_blocker(ns(TBL$TABLE_ID), message = paste(REV$MESSAGE$MULTIPLE_REVIEW))
+        on.exit(REV_hide_blocker(ns(TBL$TABLE_ID)))
+      }
+      
+      annotation_info <- state[["annotation_info"]][[dataset_list_name]][[dataset_name]]
+      changes <- REV_include_review_info(annotation_info = annotation_info, data = unfiltered_data, col_names = list())
+      if (inherits(changes, "simpleCondition")) {
+        shiny::showNotification(changes[["message"]], type = "warning")
+        warning(changes[["message"]])
+        shiny::req(FALSE)
+      }
+      
+      new_data <- changes[["data"]]
+      timestamp <- SH$get_UTC_time_in_seconds()
+      choice_index <- as.integer(info[["option"]])
+      
+      defiltered_row_indices <- local({
+        row_indices <- as.integer(info[["row"]]) # relative to the filtered data sent to the client
+        filter_mask <- attr(data(), "filter_mask")
+        res <- which(filter_mask)[row_indices]
+        return(res)
+      })
+      
+      changes <- REV_compute_review_changes(
+        data = new_data, row_indices = defiltered_row_indices, annotation_info = annotation_info, 
+        choices = review[["choices"]], choice_index = choice_index, role = role, 
+        timestamp = timestamp, dataset_list_name = dataset_list_name, dataset_name = dataset_name
       )
       
-      # Filter rows down to those present
-      filter_mask <- attr(data(), "filter_mask")
-      return(table_data[["data"]][filter_mask, ])
+      new_data <- changes[["data"]]
+      annotation_info <- changes[["annotation_info"]]
+      return(list(annotation_info = annotation_info, IO_plan = changes[["IO_plan"]]))
     })
+    
+    # IMPORTANT: overwrites global state; it has to be the _unfiltered_ annotation_info!
+    state[["annotation_info"]][[dataset_list_name]][[dataset_name]] <- 
+      changes_based_on_unfiltered_data[["annotation_info"]]
+    IO_plan <- changes_based_on_unfiltered_data[["IO_plan"]]
+    
+    # NOTE: The following code repeats the logic on the main renderDataTable reactive to match its behavior
+    #       It does so on the filtered dataset. This code is in need of deduplication. The addition of explicit filter
+    #       state to dv.manager will prove invaluable to iron out these large wrinkles
+    if (TRUE) { # NOTE: Partially repeats #weilae 
+      table_data <- list(data = data(), col_names = list())
+      filter_mask <- attr(table_data[["data"]], "filter_mask")
+      annotation_info <- state[["annotation_info"]][[dataset_list_name]][[dataset_name]] # IMPORTANT: Includes changes based on review
+      if (!all(filter_mask)) { # subset `annotation_info` to match data filter
+        annotation_info <- REV_filter_annotation_info(annotation_info, filter_mask)
+      } 
+      
+      changes <- REV_include_review_info(
+        annotation_info = annotation_info,
+        data = table_data[["data"]],
+        col_names = table_data[["col_names"]]
+      )
+      shiny::validate(shiny::need(!inherits(changes, "simpleCondition"), changes[["message"]]))
+      changes[["data"]][[REV$ID$STATUS_COL]] <- REV_compute_status(
+        dataset_review = changes[["data"]], 
+        role = role, 
+        latest_reviews_by_role = attr(annotation_info, "latest_reviews"), 
+        data_timestamps = annotation_info[["data_timestamps"]]
+      )
+      changes[["data"]][[REV$ID$LATEST_REVIEW_COL]] <- REV_review_var_to_json(
+        latest_reviews = attr(annotation_info, "latest_reviews"), 
+        data_timestamps = annotation_info[["data_timestamps"]]
+      )
+      changes[["data"]] <- relocate_column(changes[["data"]], REV$ID$LATEST_REVIEW_COL, 4L)
+      
+      table_data[["data"]] <- changes[["data"]]
+      table_data <- REV_include_highlight_info(
+        table_data, annotation_info, 
+        tracked_vars = review[["datasets"]][[selected_dataset_name()]][["tracked_vars"]]
+      )
+      
+      new_data <- table_data[["data"]]
+    }
    
     # If we were doing pure client-side rendering of DT, maybe we could do a lighter upgrade with javascript:
     # > var table = $('#DataTables_Table_0').DataTable();
@@ -1019,34 +1071,47 @@ REV_respond_to_user_review <- function(ns, state, input, review, selected_datase
       
       load_results <- REV_load_annotation_info(fs_contents, review, datasets)
       state[["annotation_info"]] <- load_results[["loaded_annotation_info"]]
-      annotation_info <- state[["annotation_info"]][[dataset_list_name]][[dataset_name]]
-      
-      unfiltered_data <- review[["data"]][[dataset_list_name]][[dataset_name]]
-      changes <- REV_include_review_info(annotation_info = annotation_info, data = unfiltered_data, col_names = list())
-      shiny::validate(shiny::need(!inherits(changes, "simpleCondition"), changes[["message"]]))
-      
-      latest_reviews <- attr(annotation_info, "latest_reviews")
-      data_timestamps <- annotation_info[["data_timestamps"]]
 
-      changes[["data"]][[REV$ID$STATUS_COL]] <- REV_compute_status(
-        changes[["data"]], role, latest_reviews, data_timestamps
-      )
-      changes[["data"]][[REV$ID$LATEST_REVIEW_COL]] <- REV_review_var_to_json(latest_reviews, data_timestamps)        
-      changes[["data"]] <- relocate_column(changes[["data"]], REV$ID$LATEST_REVIEW_COL, 4L)
-      
-      data <- changes[["data"]]
-      
-      # TODO: rewrite REV_include_highlight_info to avoid this clumsy wrapper
-      table_data <- list(data = changes[["data"]], col_names = character(0))
-      table_data <- REV_include_highlight_info(
-        table_data, annotation_info, tracked_vars = review[["datasets"]][[dataset_name]][["tracked_vars"]]
-      )
-      
-      filter_mask <- attr(data(), "filter_mask")
-      table_data[["data"]] <- table_data[["data"]][filter_mask, ]
-      
-      rownames(table_data[["data"]]) <- NULL # otherwise row numbers returned from DT are not relative to presented table
-      DT::replaceData(dt_proxy, table_data[["data"]], resetPaging = FALSE, clearSelection = "none")
+      # NOTE: The following code repeats the logic on the main renderDataTable reactive to match its behavior
+      #       It does so on the filtered dataset. This code is in need of deduplication. The addition of explicit filter
+      #       state to dv.manager will prove invaluable to iron out these large wrinkles
+      if (TRUE) { # NOTE: Partially repeats #weilae 
+        table_data <- list(data = data(), col_names = list())
+        filter_mask <- attr(table_data[["data"]], "filter_mask")
+        annotation_info <- state[["annotation_info"]][[dataset_list_name]][[dataset_name]] # IMPORTANT: Includes changes based on review
+        if (!all(filter_mask)) { # subset `annotation_info` to match data filter
+          annotation_info <- REV_filter_annotation_info(annotation_info, filter_mask)
+        } 
+        
+        changes <- REV_include_review_info(
+          annotation_info = annotation_info,
+          data = table_data[["data"]],
+          col_names = table_data[["col_names"]]
+        )
+        shiny::validate(shiny::need(!inherits(changes, "simpleCondition"), changes[["message"]]))
+        changes[["data"]][[REV$ID$STATUS_COL]] <- REV_compute_status(
+          dataset_review = changes[["data"]], 
+          role = role, 
+          latest_reviews_by_role = attr(annotation_info, "latest_reviews"), 
+          data_timestamps = annotation_info[["data_timestamps"]]
+        )
+        changes[["data"]][[REV$ID$LATEST_REVIEW_COL]] <- REV_review_var_to_json(
+          latest_reviews = attr(annotation_info, "latest_reviews"), 
+          data_timestamps = annotation_info[["data_timestamps"]]
+        )
+        changes[["data"]] <- relocate_column(changes[["data"]], REV$ID$LATEST_REVIEW_COL, 4L)
+        
+        table_data[["data"]] <- changes[["data"]]
+        table_data <- REV_include_highlight_info(
+          table_data, annotation_info, 
+          tracked_vars = review[["datasets"]][[selected_dataset_name()]][["tracked_vars"]]
+        )
+        
+        new_data <- table_data[["data"]]
+      }
+
+      rownames(new_data) <- NULL # otherwise row numbers returned from DT are not relative to presented table
+      DT::replaceData(dt_proxy, new_data, resetPaging = FALSE, clearSelection = "none")
     }
     
     undo_desc <- REV_describe_undo_action(review, REV_state = state, fs_contents, dataset_list_name, dataset_name, role)

--- a/R/review.R
+++ b/R/review.R
@@ -58,14 +58,9 @@ REV_time_from_timestamp <- function(v) {
 }
 
 REV_include_review_info <- function(annotation_info, data, col_names) {
-  if (nrow(data) < nrow(annotation_info)) {
-    filter_mask <- attr(data, "filter_mask")
-    annotation_info <- annotation_info[filter_mask, ]
-  }
-
-  if (nrow(data) > nrow(annotation_info)) 
+  if (nrow(data) != nrow(annotation_info)) 
     return(
-      simpleCondition("Internal error in `REV_include_review_info`: Annotation info has fewer rows than data listing.")
+      simpleCondition("Internal error in `REV_include_review_info`: Annotation info should have the same number of rows as the data listing.")
     )
   
   reviews <- annotation_info[["review"]]
@@ -74,7 +69,7 @@ REV_include_review_info <- function(annotation_info, data, col_names) {
   
   # include review-related columns
   res <- data.frame(reviews, roles) # FIXME: (maybe) Can't pass latest review as argument. List confuses data.frame
-  res[["status"]] <- rep(status, nrow(res)) # Explicit `rep` avoids assignment error when `nrow(res) == 0`
+  res[["status"]] <- rep(status, nrow(data)) # Explicit `rep` avoids assignment error when `nrow(data) == 0`
   names(res)[[1]] <- REV$ID$REVIEW_COL
   names(res)[[2]] <- REV$ID$ROLE_COL
   names(res)[[3]] <- REV$ID$STATUS_COL
@@ -86,12 +81,6 @@ REV_include_review_info <- function(annotation_info, data, col_names) {
  
   attributes_to_restore <- setdiff(ls(attributes(data)), c("class", "names"))
   for (e in attributes_to_restore) attr(res, e) <- attr(data, e)
- 
-  # TODO: Consider returning these as regular members of the output list
-  # TODO: Consider attaching these from the caller site instead
-  # TODO: Consider taking latest_reviews as separate input variable
-  attr(res, "latest_reviews") <- attr(annotation_info, "latest_reviews") # pass-through
-  attr(res, "data_timestamps") <- annotation_info[["data_timestamps"]] # pass-through
 
   return(list(data = res, col_names = res_col_names))
 }
@@ -106,12 +95,6 @@ REV_include_highlight_info <- function(table_data, annotation_info, tracked_vars
       review_timestamps = annotation_info[["timestamp"]]
     )
     h1 <- revisions$tracked_hashes[[length(revisions$tracked_hashes)]]
-    
-    if (nrow(data) < nrow(annotation_info)) {
-      filter_mask <- attr(data, "filter_mask")
-      h0 <- h0[, filter_mask, drop = FALSE]
-      h1 <- h1[, filter_mask, drop = FALSE]
-    }
     
     res <- REV_report_changes(h0, h1)
     for (i_row in seq_along(res)){
@@ -682,17 +665,10 @@ REV_compute_review_changes <- function(data, row_indices, annotation_info, choic
                                        dataset_list_name, dataset_name) {
   res <- list()
   
-  defiltered_row_indices <- local({
-    # `row_indices` relative to the filtered data sent to the client ...
-    filter_mask <- attr(data, "filter_mask")
-    res <- which(filter_mask)[row_indices]
-    return(res)
-  })
-  
   canonical_row_indices <- local({
-    # ... and that `row_indices` needs to be mapped into a base+deltas (stable) index
+    # `row_indices` need to be mapped into a base+deltas (stable) indices
     map_current_indices_into_canonical_order <- attr(annotation_info, "map_current_indices_into_canonical_order")
-    res <- map_current_indices_into_canonical_order(defiltered_row_indices)
+    res <- map_current_indices_into_canonical_order(row_indices)
     return(res)
   })
   
@@ -703,7 +679,7 @@ REV_compute_review_changes <- function(data, row_indices, annotation_info, choic
   data[[REV$ID$REVIEW_COL]][row_indices] <- choices[[choice_index]]
   data[[REV$ID$ROLE_COL]][row_indices] <- role
     
-  latest_reviews <- attr(data, "latest_reviews")
+  latest_reviews <- attr(annotation_info, "latest_reviews")
   latest_reviews[[role]][["review"]][row_indices] <- choices[[choice_index]]
   latest_reviews[[role]][["timestamp"]][row_indices] <- timestamp
   
@@ -878,7 +854,7 @@ REV_respond_to_user_review <- function(ns, state, input, review, selected_datase
     dataset_list_name <- selected_dataset_list_name() 
     dataset_name <- selected_dataset_name()
     
-    new_data <- data()
+    unfiltered_data <- review[["data"]][[dataset_list_name]][[dataset_name]]
     
     info <- input[[REV$ID$REVIEW_SELECT]]
 
@@ -892,11 +868,9 @@ REV_respond_to_user_review <- function(ns, state, input, review, selected_datase
       REV_show_blocker(ns(TBL$TABLE_ID), message = paste(REV$MESSAGE$MULTIPLE_REVIEW))
       on.exit(REV_hide_blocker(ns(TBL$TABLE_ID)))
     }
-
-    i_rows <- as.numeric(info[["row"]])
-    annotation_info <- state[["annotation_info"]][[dataset_list_name]][[dataset_name]]
     
-    changes <- REV_include_review_info(annotation_info = annotation_info, data = new_data, col_names = list())
+    annotation_info <- state[["annotation_info"]][[dataset_list_name]][[dataset_name]]
+    changes <- REV_include_review_info(annotation_info = annotation_info, data = unfiltered_data, col_names = list())
     if (inherits(changes, "simpleCondition")) {
       shiny::showNotification(changes[["message"]], type = "warning")
       warning(changes[["message"]])
@@ -907,19 +881,27 @@ REV_respond_to_user_review <- function(ns, state, input, review, selected_datase
     timestamp <- SH$get_UTC_time_in_seconds()
     choice_index <- as.integer(info[["option"]])
     
+    defiltered_row_indices <- local({
+      row_indices <- as.integer(info[["row"]]) # relative to the filtered data sent to the client
+      filter_mask <- attr(data(), "filter_mask")
+      res <- which(filter_mask)[row_indices]
+      return(res)
+    })
+    
     changes <- REV_compute_review_changes(
-      data = new_data, row_indices = i_rows, annotation_info = annotation_info, 
+      data = new_data, row_indices = defiltered_row_indices, annotation_info = annotation_info, 
       choices = review[["choices"]], choice_index = choice_index,  role = role, 
       timestamp = timestamp, dataset_list_name = dataset_list_name, dataset_name = dataset_name
     )
     
     new_data <- changes[["data"]]
     annotation_info <- changes[["annotation_info"]]
+    # IMPORTANT: overwrites global state; it has to be the _unfiltered_ annotation_info!
     state[["annotation_info"]][[dataset_list_name]][[dataset_name]] <- annotation_info
     IO_plan <- changes[["IO_plan"]]
     
     latest_reviews <- attr(changes[["data"]], "latest_reviews")
-    data_timestamps <- attr(changes[["data"]], "data_timestamps")
+    data_timestamps <- annotation_info[["data_timestamps"]]
 
     # TODO: Benchmark to decide if this is a bottleneck for bigger datasets
     new_data[[REV$ID$STATUS_COL]] <- REV_compute_status(new_data, role, latest_reviews, data_timestamps)
@@ -933,7 +915,10 @@ REV_respond_to_user_review <- function(ns, state, input, review, selected_datase
         table_data, annotation_info, 
         tracked_vars = review[["datasets"]][[dataset_name]][["tracked_vars"]]
       )
-      return(table_data[["data"]])
+      
+      # Filter rows down to those present
+      filter_mask <- attr(data(), "filter_mask")
+      return(table_data[["data"]][filter_mask, ])
     })
    
     # If we were doing pure client-side rendering of DT, maybe we could do a lighter upgrade with javascript:
@@ -942,6 +927,7 @@ REV_respond_to_user_review <- function(ns, state, input, review, selected_datase
     # > table.columns()[0].length;
     # > tmp[9] = '2';
     # > table.row(5).data(tmp).invalidate();
+    rownames(new_data) <- NULL # otherwise row numbers returned from DT are not relative to presented table
     DT::replaceData(dt_proxy, new_data, resetPaging = FALSE, clearSelection = "none")
     
     fs_execute_IO_plan(IO_plan, callback = update_undo_description_callback)
@@ -1028,12 +1014,13 @@ REV_respond_to_user_review <- function(ns, state, input, review, selected_datase
       state[["annotation_info"]] <- load_results[["loaded_annotation_info"]]
       annotation_info <- state[["annotation_info"]][[dataset_list_name]][[dataset_name]]
       
-      data <- data()
-      changes <- REV_include_review_info(annotation_info = annotation_info, data = data, col_names = list())
+      unfiltered_data <- review[["data"]][[dataset_list_name]][[dataset_name]]
+      changes <- REV_include_review_info(annotation_info = annotation_info, data = unfiltered_data, col_names = list())
       shiny::validate(shiny::need(!inherits(changes, "simpleCondition"), changes[["message"]]))
       
-      latest_reviews <- attr(changes[["data"]], "latest_reviews")
-      data_timestamps <- attr(changes[["data"]], "data_timestamps")
+      latest_reviews <- attr(annotation_info, "latest_reviews")
+      data_timestamps <- annotation_info[["data_timestamps"]]
+
       changes[["data"]][[REV$ID$STATUS_COL]] <- REV_compute_status(
         changes[["data"]], role, latest_reviews, data_timestamps
       )
@@ -1043,11 +1030,15 @@ REV_respond_to_user_review <- function(ns, state, input, review, selected_datase
       data <- changes[["data"]]
       
       # TODO: rewrite REV_include_highlight_info to avoid this clumsy wrapper
-      table_data <- list(data = data, col_names = character(0))
+      table_data <- list(data = changes[["data"]], col_names = character(0))
       table_data <- REV_include_highlight_info(
         table_data, annotation_info, tracked_vars = review[["datasets"]][[dataset_name]][["tracked_vars"]]
       )
       
+      filter_mask <- attr(data(), "filter_mask")
+      table_data[["data"]] <- table_data[["data"]][filter_mask, ]
+      
+      rownames(table_data[["data"]]) <- NULL # otherwise row numbers returned from DT are not relative to presented table
       DT::replaceData(dt_proxy, table_data[["data"]], resetPaging = FALSE, clearSelection = "none")
     }
     

--- a/R/review.R
+++ b/R/review.R
@@ -57,6 +57,8 @@ REV_time_from_timestamp <- function(v) {
   return(res)
 }
 
+# Prepends review columns to those of the `data` table
+# Prepends review column names to `col_names`
 REV_include_review_info <- function(annotation_info, data, col_names) {
   if (nrow(data) != nrow(annotation_info)) 
     return(
@@ -75,7 +77,7 @@ REV_include_review_info <- function(annotation_info, data, col_names) {
   names(res)[[3]] <- REV$ID$STATUS_COL
   res_col_names <- c(REV$LABEL$REVIEW_COLS)
  
-  # add actual data
+  # append actual data columns
   res <- cbind(res, data)
   res_col_names <- c(res_col_names, col_names)
  
@@ -85,6 +87,13 @@ REV_include_review_info <- function(annotation_info, data, col_names) {
   return(list(data = res, col_names = res_col_names))
 }
 
+# Append columns named "__<NAME_OF_COLUMN>_highlight__" for each of the tracked columns, indicating
+# altered cell data. Example:
+# >   ID TRACKED_1 TRACKED_2 UNTRACKED __TRACKED_1_highlight__ __TRACKED_2_highlight__ 
+# > 1  1         3         3         7                    TRUE                   FALSE 
+# > 2  2         4         7        14                   FALSE                   FALSE 
+# > 3  3         6         9        21                   FALSE                   FALSE 
+# Row 1 of the TRACKED_1 column has been altered after review.
 REV_include_highlight_info <- function(table_data, annotation_info, tracked_vars) {
   data <- table_data[["data"]]
   # Compute dataset changes that make current reviews obsolete
@@ -683,7 +692,6 @@ REV_compute_review_changes <- function(data, row_indices, annotation_info, choic
   latest_reviews[[role]][["review"]][row_indices] <- choices[[choice_index]]
   latest_reviews[[role]][["timestamp"]][row_indices] <- timestamp
   
-  attr(data, "latest_reviews") <- latest_reviews 
   attr(annotation_info, "latest_reviews") <- latest_reviews
   
   # `REV_load_annotation_info()` would return this same (modified) state, but we do manual synchronization
@@ -900,10 +908,9 @@ REV_respond_to_user_review <- function(ns, state, input, review, selected_datase
     state[["annotation_info"]][[dataset_list_name]][[dataset_name]] <- annotation_info
     IO_plan <- changes[["IO_plan"]]
     
-    latest_reviews <- attr(changes[["data"]], "latest_reviews")
+    latest_reviews <- attr(annotation_info, "latest_reviews")
     data_timestamps <- annotation_info[["data_timestamps"]]
 
-    # TODO: Benchmark to decide if this is a bottleneck for bigger datasets
     new_data[[REV$ID$STATUS_COL]] <- REV_compute_status(new_data, role, latest_reviews, data_timestamps)
     new_data[[REV$ID$LATEST_REVIEW_COL]] <- REV_review_var_to_json(latest_reviews, data_timestamps)
     new_data <- relocate_column(new_data, REV$ID$LATEST_REVIEW_COL, 4L)

--- a/R/review.R
+++ b/R/review.R
@@ -1073,7 +1073,7 @@ REV_review_var_to_json <- function(latest_reviews, data_timestamps) {
   }
   reviews <- do.call(paste, c(review_pieces, sep = ","))
   
-  res <- paste0('{"reviews":{', reviews, sprintf('},"data_timestamp":%.3f}', data_timestamps))
+  res <- sprintf('{"reviews":{%s},"data_timestamp":%.3f}', reviews, data_timestamps)
   return(res)
 }
 


### PR DESCRIPTION
Filtering data with the dv.manager filters make the review functionality fail:
<img width="1513" height="667" alt="image" src="https://github.com/user-attachments/assets/8466d5cf-223d-4104-9d6c-ec276bde04b9" />

The immediate cause of this failure is easy to find and patch, but that is the first of a few routines that would need patching. Instead of doing that, I've decided to isolate the influence of the filter on the review functionality into fewer pockets of code. This means that:

- `REV_include_review_info` doesn't care about filter state. It expects all arguments to have the same number of rows.
- The same goes for `REV_include_highlight_info` and `REV_compute_review_changes`.
-  `observeEvent(input[[REV$ID$REVIEW_SELECT]])` (inside `REV_respond_to_user_review`) now operates on the full unfiltered dataset, as it has to update the global variable `REV_state`, which needs to remain independent of filter state.
- There are three locations in the module that are allowed to update the displayed table data:
    - The main `output[[TBL$TABLE_ID]] <- DT::renderDataTable` output, which now explicitly narrows down `annotation_info` to match the filter state.
    - `observeEvent(input[[REV$ID$REVIEW_SELECT]])` (inside `REV_respond_to_user_review`), which works on the full dataset and only filters it down before issuing a `DT::replaceData`.
    - the `update_table_and_undo_description_callback` also works on the full dataset and filters it down before `replaceData`

Other than that, I've ironed out some clunky data pass-through that required some calls to be chained in a specific order, coupling the affected functions.

# Hotfix checklist

- [ ] Bumped minor version number on both DESCRIPTION and NEWS.md

- [ ] Build passes pipeline checks

- [ ] The new changes do not affect the API

- [ ] The new changes do not affect the documentation (including screenshots)

- [ ] The new changes do not impact the QC report

