### PR TITLE
343777 sanitize names

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: dv.listings
 Type: Package
 Title: Data listings module
-Version: 4.3.4-9002
+Version: 4.3.4-9003
 Authors@R: 
     c(
       person("Boehringer-Ingelheim Pharma GmbH & Co.KG", role = c("cph", "fnd")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# dv.listings 4.3.4-9003
+- Review functionality:
+  - Guard against problematic characters in dataset names
+
 # dv.listings 4.3.4-9002
 - Review functionality:
   - Cope with initially empty datasets

--- a/R/mod_listings.R
+++ b/R/mod_listings.R
@@ -993,7 +993,7 @@ check_mod_listings <- function(afmm, datasets, module_id, dataset_names,
     )
   )
 
-  check_review_parameter(afmm, datasets, dataset_names, review, err)
+  check_review_parameter(datasets, dataset_names, review, err, afmm)
   
   res <- list(errors = err[["messages"]])
   return(res)

--- a/R/mod_listings.R
+++ b/R/mod_listings.R
@@ -993,7 +993,7 @@ check_mod_listings <- function(afmm, datasets, module_id, dataset_names,
     )
   )
 
-  check_review_parameter(datasets, dataset_names, review, err)
+  check_review_parameter(afmm, datasets, dataset_names, review, err)
   
   res <- list(errors = err[["messages"]])
   return(res)

--- a/R/review.R
+++ b/R/review.R
@@ -1290,6 +1290,10 @@ REV_report_changes <- function(h0, h1, verbose = FALSE) {
 
 #' Early error feedback function for the optional review parameter
 #'
+#' @param afmm
+#' 
+#' Pass-through of the server afmm parameter.
+#' 
 #' @param datasets `[list(data.frame)]`
 #'
 #' Available datasets for review.
@@ -1307,7 +1311,7 @@ REV_report_changes <- function(h0, h1, verbose = FALSE) {
 #' the configuration of the review parameter will be placed here.
 #' 
 #' @export
-check_review_parameter <- function(datasets, dataset_names, review, err) {
+check_review_parameter <- function(afmm, datasets, dataset_names, review, err) {
   if (is.null(review)) return(NULL)
   ok <- CM$assert(
     container = err,
@@ -1443,4 +1447,48 @@ check_review_parameter <- function(datasets, dataset_names, review, err) {
       )
     }
   }
+  if (!ok) return(NULL)
+ 
+  # https://en.wikipedia.org/wiki/Filename#Problematic_characters 
+  problematic_chars <- c("/", "\\\\", "?", "%", "*", ":", "|", '"', "<", ">", ".", ",", ";", "=")
+  problematic_chars_regexp <- paste("([", paste(problematic_chars, collapse = ""), "])")
+  
+  report_problematic_names <- function(message_template, v) {
+    res <- character(0)
+    for (e in v){
+      matches <- character(0)
+      for (pc in problematic_chars) if (grepl(pc, e, fixed = TRUE)) {
+        single_char <- substr(pc, 1, 1) # deals with backslash
+        matches <- c(matches, single_char)
+      }
+      if (length(matches)) {
+        res <- c(res, sprintf(message_template, e, paste(sprintf("'<b>%s</b>'", matches), collapse = ", ")))
+      }
+    }
+    res <- paste(res, collapse = "<br>")
+    return(res)
+  }
+  
+  dataset_list_names <- names(afmm[["data"]])
+  CM$assert(
+    container = err,
+    cond = !any(grepl(problematic_chars_regexp, dataset_list_names)),
+    msg = report_problematic_names(
+      paste('The dataset list name "<b>%s</b>" contains characters (%s) incompatible with the review functionality.',
+            "That string would be used as part of review-related folder names and those characters could cause problems",
+            '<a href="https://en.wikipedia.org/wiki/Filename#Problematic_characters" target="_blank">(details)<a>.',
+            "Please, exclude them."),
+      dataset_list_names)
+  ) 
+  dataset_names <- names(review[["datasets"]])
+  CM$assert(
+    container = err,
+    cond = !any(grepl(problematic_chars_regexp, dataset_names)),
+    msg = report_problematic_names(
+      paste('The dataset name "<b>%s</b>" contains characters (%s) incompatible with the review functionality.',
+            "That string would be used as part of review-related file names and those characters could cause problems",
+            '<a href="https://en.wikipedia.org/wiki/Filename#Problematic_characters" target="_blank">(details)<a>.',
+            "Please, exclude them."),
+      dataset_names)
+  )
 }

--- a/R/review.R
+++ b/R/review.R
@@ -1468,7 +1468,7 @@ check_review_parameter <- function(datasets, dataset_names, review, err, afmm = 
     res <- paste(res, collapse = "<br>")
     return(res)
   }
-  if(!is.null(afmm)) {
+  if (!is.null(afmm)) {
     dataset_list_names <- names(afmm[["data"]])
     CM$assert(
       container = err,

--- a/R/review.R
+++ b/R/review.R
@@ -1289,10 +1289,6 @@ REV_report_changes <- function(h0, h1, verbose = FALSE) {
 }
 
 #' Early error feedback function for the optional review parameter
-#'
-#' @param afmm
-#' 
-#' Pass-through of the server afmm parameter.
 #' 
 #' @param datasets `[list(data.frame)]`
 #'
@@ -1309,9 +1305,13 @@ REV_report_changes <- function(h0, h1, verbose = FALSE) {
 #' @param err `[environment]`
 #' This environment has at least one element named "messages". It is a character vector. Diagnostic messages related to
 #' the configuration of the review parameter will be placed here.
+#'
+#' @param afmm
 #' 
+#' Pass-through of the server afmm parameter.
+#'
 #' @export
-check_review_parameter <- function(afmm, datasets, dataset_names, review, err) {
+check_review_parameter <- function(datasets, dataset_names, review, err, afmm = NULL) {
   if (is.null(review)) return(NULL)
   ok <- CM$assert(
     container = err,
@@ -1468,18 +1468,19 @@ check_review_parameter <- function(afmm, datasets, dataset_names, review, err) {
     res <- paste(res, collapse = "<br>")
     return(res)
   }
-  
-  dataset_list_names <- names(afmm[["data"]])
-  CM$assert(
-    container = err,
-    cond = !any(grepl(problematic_chars_regexp, dataset_list_names)),
-    msg = report_problematic_names(
-      paste('The dataset list name "<b>%s</b>" contains characters (%s) incompatible with the review functionality.',
-            "That string would be used as part of review-related folder names and those characters could cause problems",
-            '<a href="https://en.wikipedia.org/wiki/Filename#Problematic_characters" target="_blank">(details)<a>.',
-            "Please, exclude them."),
-      dataset_list_names)
-  ) 
+  if(!is.null(afmm)) {
+    dataset_list_names <- names(afmm[["data"]])
+    CM$assert(
+      container = err,
+      cond = !any(grepl(problematic_chars_regexp, dataset_list_names)),
+      msg = report_problematic_names(
+        paste('The dataset list name "<b>%s</b>" contains characters (%s) incompatible with the review functionality.',
+              "That string would be used as part of review-related folder names and those characters could cause problems",
+              '<a href="https://en.wikipedia.org/wiki/Filename#Problematic_characters" target="_blank">(details)<a>.',
+              "Please, exclude them."),
+        dataset_list_names)
+    ) 
+  }
   dataset_names <- names(review[["datasets"]])
   CM$assert(
     container = err,

--- a/man/check_review_parameter.Rd
+++ b/man/check_review_parameter.Rd
@@ -4,11 +4,9 @@
 \alias{check_review_parameter}
 \title{Early error feedback function for the optional review parameter}
 \usage{
-check_review_parameter(afmm, datasets, dataset_names, review, err)
+check_review_parameter(datasets, dataset_names, review, err, afmm = NULL)
 }
 \arguments{
-\item{afmm}{Pass-through of the server afmm parameter.}
-
 \item{datasets}{\verb{[list(data.frame)]}
 
 Available datasets for review.}
@@ -24,6 +22,8 @@ Configuration of the experimental data review feature. Please refer to \code{vig
 \item{err}{\verb{[environment]}
 This environment has at least one element named "messages". It is a character vector. Diagnostic messages related to
 the configuration of the review parameter will be placed here.}
+
+\item{afmm}{Pass-through of the server afmm parameter.}
 }
 \description{
 Early error feedback function for the optional review parameter

--- a/man/check_review_parameter.Rd
+++ b/man/check_review_parameter.Rd
@@ -4,9 +4,11 @@
 \alias{check_review_parameter}
 \title{Early error feedback function for the optional review parameter}
 \usage{
-check_review_parameter(datasets, dataset_names, review, err)
+check_review_parameter(afmm, datasets, dataset_names, review, err)
 }
 \arguments{
+\item{afmm}{Pass-through of the server afmm parameter.}
+
 \item{datasets}{\verb{[list(data.frame)]}
 
 Available datasets for review.}

--- a/tests/testthat/test-review.R
+++ b/tests/testthat/test-review.R
@@ -237,3 +237,23 @@ test_that("REV_compute_status preserves expected behavior", {
   expect_equal(res, factor(c("Conflict", "Pending", "Pending"), levels = res_levels))
 })
 
+test_that("check_review_parameter warns against problematic characters in dataset names", {
+  mock_afmm = list(data = list(`dataset_list/not_allowed` = NULL))
+  review <- list(
+    datasets = list("not/allowed" = list(id_vars = c("USUBJID", "AESEQ"), 
+                                         tracked_vars = c("TRACKED_1", "TRACKED_2", "TRACKED_3"))),
+    choices = c("choiceA", "choiceB"), roles = c("roleA", "roleB")
+  )
+  
+  err <- CM$container()
+  check_review_parameter(
+    afmm = mock_afmm, 
+    datasets = list(), 
+    dataset_names = c("not/allowed"), 
+    review = review, 
+    err = err
+  )
+  
+  expect_true(any(grepl("Problematic_characters", err[["messages"]])))
+})
+

--- a/tests/testthat/test-review.R
+++ b/tests/testthat/test-review.R
@@ -247,11 +247,11 @@ test_that("check_review_parameter warns against problematic characters in datase
   
   err <- CM$container()
   check_review_parameter(
-    afmm = mock_afmm, 
     datasets = list(), 
     dataset_names = c("not/allowed"), 
     review = review, 
-    err = err
+    err = err,
+    afmm = mock_afmm
   )
   
   expect_true(any(grepl("Problematic_characters", err[["messages"]])))


### PR DESCRIPTION
I've taken the approach of guarding against the characters listed [here](https://en.wikipedia.org/wiki/Filename#Problematic_characters) as part of the early error feedback. Here's a sample message:
<img width="1059" height="233" alt="image" src="https://github.com/user-attachments/assets/a7d5c963-ec88-4d0e-9c52-702f76617732" />

There's a bit of weirdness in the changes to the signature of `check_review_parameter`. I think it would make more sense to put `afmm` at the beginning, but I've pushed it to the end so that old versions of `dv.tables::mod_Tplyr_table` work unmodified. I think it was me that wrote the `dv.tables` call to `check_review_parameter`, so I know who to blame.


# Critical checks

- [x] Is the test version number correct (x.x.x-9000)? 

- [x] DESCRIPTION file

- [x] NEWS.md

- [x] Does the build pass?

---

## Documentation

Does it include the following sections?

- [ ] Module introduction with features
  - [ ] (O) Screenshots

- [ ] Installation details

- [ ] Explanation of function arguments

- [ ] Data specifications and requirements

- [ ] Different possible visualizations

- [ ] Are the changes/new features included in NEWS.md?
  - [ ] (O) Screenshots

- [ ] (O) Explanation of input menus

- [ ] (O) Short articles on building the app, compatibility with other modules, known bugs,...

---

## QC Report

- [ ] Does it include a QC Report with positive outcome?

- [ ] Are the new features reflected accordingly in the specs?

---

## API conventions

- [ ] Follows API convention
