### PR TITLE
[review] Expand revision count limit from 1000 to 10000 entries

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: dv.listings
 Type: Package
 Title: Data listings module
-Version: 4.3.4-9003
+Version: 4.3.4-9004
 Authors@R: 
     c(
       person("Boehringer-Ingelheim Pharma GmbH & Co.KG", role = c("cph", "fnd")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# dv.listings 4.3.4-9004
+- Review functionality:
+  - Expand revision count limit from 1000 to 10000 entries
+
 # dv.listings 4.3.4-9003
 - Review functionality:
   - Guard against problematic characters in dataset names

--- a/R/review.R
+++ b/R/review.R
@@ -267,8 +267,8 @@ REV_load_annotation_info <- function(folder_contents, review, dataset_lists) {
       base_file_path_pattern <- sprintf("^%s_0+.base$", file.path(dataset_lists_name, dataset_review_name))
       base_file_path <- grep(base_file_path_pattern, names(folder_contents), value = TRUE)
       if (length(base_file_path) > 1L) {
-        error <<- c(error,  paste0("[", dataset_review_name, "] ", "Multiple `.base` files found:\n",
-                                   paste(sprintf("`%s`", base_file_path), collapse = ", "), ".\n"))
+        error <- c(error, paste0("[", dataset_review_name, "] ", "Multiple `.base` files found:\n",
+                                 paste(sprintf("`%s`", base_file_path), collapse = ", "), ".\n"))
         base_file_path <- sort(base_file_path)[[1]]
       }
       

--- a/R/review.R
+++ b/R/review.R
@@ -259,10 +259,10 @@ REV_load_annotation_info <- function(folder_contents, review, dataset_lists) {
      
       base_timestamp <- NA_real_
       data_timestamps_st <- rep(NA_real_, row_count)
-      # <domain>_000.base
-      file_path <- file.path(dataset_lists_name, paste0(dataset_review_name, "_000.base"))
-      if (file_path %in% names(folder_contents)) {
-        contents <- folder_contents[[file_path]]        
+      # <domain>_0000.base
+      base_file_path <- file.path(dataset_lists_name, paste0(dataset_review_name, "_0000.base"))
+      if (base_file_path %in% names(folder_contents)) {
+        contents <- folder_contents[[base_file_path]]        
 
         sorted_delta_file_paths <- local({
           pattern <- sprintf("^%s_[0-9]*.delta", file.path(dataset_lists_name, dataset_review_name))
@@ -383,7 +383,10 @@ REV_load_annotation_info <- function(folder_contents, review, dataset_lists) {
               base_info <- RS_load(contents, deltas)
               
               delta_number <- length(sorted_delta_file_paths) + 1
-              file_path <- file.path(dataset_lists_name, sprintf("%s_%03d.delta", dataset_review_name, delta_number))
+              revision_digit_count <- nchar(sub(".*_(0+)\\.base$", "\\1", base_file_path))
+              file_path <- file.path(
+                dataset_lists_name, sprintf("%s_%.*d.delta", dataset_review_name, revision_digit_count, delta_number)
+              )
               append_IO_action(list(kind = "write", path = file_path, contents = new_delta_contents, offset = 0L))
             }
         }
@@ -394,7 +397,7 @@ REV_load_annotation_info <- function(folder_contents, review, dataset_lists) {
           return(list(error = c(error, contents[["message"]])))
         } else {
           base_info <- RS_load(base = contents, deltas = list())
-          append_IO_action(list(kind = "write", path = file_path, contents = contents, offset = 0L))
+          append_IO_action(list(kind = "write", path = base_file_path, contents = contents, offset = 0L))
         }
       }
       

--- a/R/review.R
+++ b/R/review.R
@@ -259,9 +259,20 @@ REV_load_annotation_info <- function(folder_contents, review, dataset_lists) {
      
       base_timestamp <- NA_real_
       data_timestamps_st <- rep(NA_real_, row_count)
+      
       # <domain>_0000.base
-      base_file_path <- file.path(dataset_lists_name, paste0(dataset_review_name, "_0000.base"))
-      if (base_file_path %in% names(folder_contents)) {
+      # - Older versions of the review functionality devoted three digits to the `.base` and `.delta` sequence numbers.
+      #   The current version uses four digits. Here we detect the one that was used for this particular domain (if it
+      #   exists) and use it for the associated delta files.
+      base_file_path_pattern <- sprintf("^%s_0+.base$", file.path(dataset_lists_name, dataset_review_name))
+      base_file_path <- grep(base_file_path_pattern, names(folder_contents), value = TRUE)
+      if (length(base_file_path) > 1L) {
+        error <<- c(error,  paste0("[", dataset_review_name, "] ", "Multiple `.base` files found:\n",
+                                   paste(sprintf("`%s`", base_file_path), collapse = ", "), ".\n"))
+        base_file_path <- sort(base_file_path)[[1]]
+      }
+      
+      if (length(base_file_path) == 1) { # existing `.base` file
         contents <- folder_contents[[base_file_path]]        
 
         sorted_delta_file_paths <- local({
@@ -390,7 +401,8 @@ REV_load_annotation_info <- function(folder_contents, review, dataset_lists) {
               append_IO_action(list(kind = "write", path = file_path, contents = new_delta_contents, offset = 0L))
             }
         }
-      } else {
+      } else { # new `.base` file
+        base_file_path <- file.path(dataset_lists_name, paste0(dataset_review_name, "_0000.base"))
         contents <- RS_compute_base_memory(dataset_review_name, dataset, id_vars, tracked_vars)
         if (inherits(contents, "simpleCondition")) {
           # IMPORTANT: Not being able to compute the base info is too severe an error to recover from, so we error out

--- a/tests/testthat/test-review.R
+++ b/tests/testthat/test-review.R
@@ -44,7 +44,7 @@ local({
     expect_length(info[["IO_plan"]], 1)
     folder_op <- info[["IO_plan"]][[1]]
     expect_equal(folder_op[["kind"]], "write")
-    expect_equal(folder_op[["path"]], "dataset_list/ae_001.delta")
+    expect_equal(folder_op[["path"]], "dataset_list/ae_0001.delta")
     expect_equal(folder_op[["offset"]], 0L)
     
     delta <- RS_parse_delta(info[["IO_plan"]][[1]][["contents"]], length(tracked_vars))

--- a/vignettes/data_review.Rmd
+++ b/vignettes/data_review.Rmd
@@ -157,7 +157,7 @@ Lastly, using plain file storage allows for easy local testing and for universal
 
 If we take a hypothetical "xyz" domain, `dv.listings` will store the following files for review purposes (expand to see the layout of their contents):
 
-<details><summary>`xyz_000.base` (information related to the first version of the "xyz" domain dataset seen by the module)</summary>
+<details><summary>`xyz_0000.base` (information related to the first version of the "xyz" domain dataset seen by the module)</summary>
 - 1 file magic code ("LISTBASE")
 - 1 format version number (0)
 - 1 generation marker (0)
@@ -173,7 +173,7 @@ If we take a hypothetical "xyz" domain, `dv.listings` will store the following f
 - p (1 per "xyz" row, 2\*m bytes long) `hash_tracked(xyz[tracked_vars])`
 </details>
 
-<details><summary>`xyz_001.delta` (one per domain dataset update)</summary>
+<details><summary>`xyz_0001.delta` (one per domain dataset update)</summary>
 - 1 file magic code ("LISTDELT")
 - 1 format version number (0)
 - 1 generation marker (1). Wraps around to 0 after 255 (e.g. for `xyz_256.delta`)


### PR DESCRIPTION
The simplest solution is to bump the number of digits dedicated to revisions from _three_ to _four_. That would allow studies to have ten thousand data revisions, which would mean one revision per day for more than 27 years.

The only issue is what happens to studies that are already in progress. Instead of forcing them to migrate from the old naming scheme to the new one, what we can do is:

Every new `.base` file that we create gets four digits (e.g. `domain_0000.base`). Only newly added domains create `.base` files. Old ones are OK having only three digits.

Every new `.delta` file gets the amount of digits that its .base counterpart has. This means that old studies keep using three-digit `.delta` names and new ones get four digits.

I've tested this approach against the “review oracle”, letting it create 1500 revisions and it works. I won't leave that change in the codebase, because it takes ages to run:
<img width="584" height="63" alt="image" src="https://github.com/user-attachments/assets/157ab25e-ec1d-41b3-b915-29ba14f75024" />


# Critical checks

- [x] Is the test version number correct (x.x.x-9000)? 

- [x] DESCRIPTION file

- [x] NEWS.md

- [x] Does the build pass?

---

## Documentation

Does it include the following sections?

- [ ] Module introduction with features
  - [ ] (O) Screenshots

- [ ] Installation details

- [ ] Explanation of function arguments

- [ ] Data specifications and requirements

- [ ] Different possible visualizations

- [ ] Are the changes/new features included in NEWS.md?
  - [ ] (O) Screenshots

- [ ] (O) Explanation of input menus

- [ ] (O) Short articles on building the app, compatibility with other modules, known bugs,...

---

## QC Report

- [ ] Does it include a QC Report with positive outcome?

- [ ] Are the new features reflected accordingly in the specs?

---

## API conventions

- [ ] Follows API convention
