### PR TITLE
385292 ignore outdated timestamps

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: dv.listings
 Type: Package
 Title: Data listings module
-Version: 4.3.4-9007
+Version: 4.3.4-9008
 Authors@R: 
     c(
       person("Boehringer-Ingelheim Pharma GmbH & Co.KG", role = c("cph", "fnd")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# dv.listings 4.3.4-9008
+- Review functionality:
+  - Remove column change highlighting from rows that have been modified but restored afterwards
+
 # dv.listings 4.3.4-9007
 - Review functionality:
   - Fix bug in column change highlight when known rows are removed

--- a/R/review.R
+++ b/R/review.R
@@ -1097,7 +1097,7 @@ REV_review_var_to_json <- function(latest_reviews, data_timestamps) {
   return(res)
 }
 
-REV_compute_status <- function(dataset_review, role, latest_reviews_by_role, data_timestamps, row_is_outdated) {
+REV_compute_status <- function(dataset_review, role, latest_reviews_by_role, data_timestamps, modified_row_mask) {
   # Does this function make sense with no role? Yes it does because the latest review is the one that may be outdated,
   # conflicting, unreviewed, etc.
   # Optionally, we could indicate if the current role does have a conflict or is it someone else?
@@ -1152,7 +1152,7 @@ REV_compute_status <- function(dataset_review, role, latest_reviews_by_role, dat
   # [3] A conflict in which the current role participates deserves even more attention
   res[conflict_with_role_mask] <- REV$STATUS_LEVELS$CONFLICT_ROLE
   # [4] But a review based on outdated information is the most relevant
-  res[outdated_latest_mask & row_is_outdated] <- REV$STATUS_LEVELS$LATEST_OUTDATED
+  res[outdated_latest_mask & modified_row_mask] <- REV$STATUS_LEVELS$LATEST_OUTDATED
   
   return(res)
 }
@@ -1223,7 +1223,7 @@ REV_report_changes <- function(h0, h1, verbose = FALSE) {
 REV_include_review_interface <- function(table_data, annotation_info, role, tracked_vars) {
   main_review_columns <- REV_compute_main_review_columns(annotation_info = annotation_info)
 
-  # NOTE: The purpose of `row_is_outdated` is to address discrepancies between the "Status" column and the 
+  # NOTE: The purpose of `modified_row_mask` is to address discrepancies between the "Status" column and the 
   # orange highlighting of individual tracked columns:
   # - The contents of the "Status" column are calculated looking only at data and review timestamps. A review
   #   is marked as outdated if it precedes a data change.
@@ -1236,10 +1236,10 @@ REV_include_review_interface <- function(table_data, annotation_info, role, trac
   # 
   # In this case, the review of row A will be tagged as "Outdated" but no highlighting will appear.
   #
-  # Here we take a shortcut to address this discrepancy. We create an `row_is_outdated` mask based on the
+  # Here we take a shortcut to address this discrepancy. We create an `modified_row_mask` mask based on the
   # information provided by the column highlighting routine (which is based on the contents of a row) and
   # use it to filter out the misleading "Outdated" tags of rows that have been modified and rolled back.
-  row_is_outdated <- local({
+  modified_row_mask <- local({
     highlight_columns_tmp <- REV_compute_highlight_info(
       annotation_info = annotation_info, 
       tracked_vars = tracked_vars,
@@ -1253,7 +1253,7 @@ REV_include_review_interface <- function(table_data, annotation_info, role, trac
     role = role, 
     latest_reviews_by_role = attr(annotation_info, "latest_reviews"), 
     data_timestamps = annotation_info[["data_timestamps"]],
-    row_is_outdated
+    modified_row_mask
   )
   
   main_review_columns[[REV$ID$LATEST_REVIEW_COL]] <- REV_review_var_to_json(

--- a/R/review.R
+++ b/R/review.R
@@ -1223,6 +1223,22 @@ REV_report_changes <- function(h0, h1, verbose = FALSE) {
 REV_include_review_interface <- function(table_data, annotation_info, role, tracked_vars) {
   main_review_columns <- REV_compute_main_review_columns(annotation_info = annotation_info)
 
+  # NOTE: The purpose of `row_is_outdated` is to address discrepancies between the "Status" column and the 
+  # orange highlighting of individual tracked columns:
+  # - The contents of the "Status" column are calculated looking only at data and review timestamps. A review
+  #   is marked as outdated if it precedes a data change.
+  # - The orange highlighting is calculated based on the hash of the _contents_ of the cells, instead.
+  #
+  # There is a situation in which these two ways of computing review status disagree:
+  # - there was a review of row A
+  # - there was a dataset update that modified row A
+  # - there was a dataset update that reverted row A to the state it had prior to the review
+  # 
+  # In this case, the review of row A will be tagged as "Outdated" but no highlighting will appear.
+  #
+  # Here we take a shortcut to address this discrepancy. We create an `row_is_outdated` mask based on the
+  # information provided by the column highlighting routine (which is based on the contents of a row) and
+  # use it to filter out the misleading "Outdated" tags of rows that have been modified and rolled back.
   row_is_outdated <- local({
     highlight_columns_tmp <- REV_compute_highlight_info(
       annotation_info = annotation_info, 

--- a/R/review.R
+++ b/R/review.R
@@ -1097,7 +1097,7 @@ REV_review_var_to_json <- function(latest_reviews, data_timestamps) {
   return(res)
 }
 
-REV_compute_status <- function(dataset_review, role, latest_reviews_by_role, data_timestamps) {
+REV_compute_status <- function(dataset_review, role, latest_reviews_by_role, data_timestamps, row_is_outdated) {
   # Does this function make sense with no role? Yes it does because the latest review is the one that may be outdated,
   # conflicting, unreviewed, etc.
   # Optionally, we could indicate if the current role does have a conflict or is it someone else?
@@ -1152,7 +1152,7 @@ REV_compute_status <- function(dataset_review, role, latest_reviews_by_role, dat
   # [3] A conflict in which the current role participates deserves even more attention
   res[conflict_with_role_mask] <- REV$STATUS_LEVELS$CONFLICT_ROLE
   # [4] But a review based on outdated information is the most relevant
-  res[outdated_latest_mask] <- REV$STATUS_LEVELS$LATEST_OUTDATED
+  res[outdated_latest_mask & row_is_outdated] <- REV$STATUS_LEVELS$LATEST_OUTDATED
   
   return(res)
 }
@@ -1222,12 +1222,22 @@ REV_report_changes <- function(h0, h1, verbose = FALSE) {
 
 REV_include_review_interface <- function(table_data, annotation_info, role, tracked_vars) {
   main_review_columns <- REV_compute_main_review_columns(annotation_info = annotation_info)
+
+  row_is_outdated <- local({
+    highlight_columns_tmp <- REV_compute_highlight_info(
+      annotation_info = annotation_info, 
+      tracked_vars = tracked_vars,
+      status = rep(REV$STATUS_LEVELS$LATEST_OUTDATED, nrow(main_review_columns))
+    )
+    return(as.logical(rowSums(highlight_columns_tmp)))
+  })
   
   main_review_columns[[REV$ID$STATUS_COL]] <- REV_compute_status(
     dataset_review = main_review_columns, 
     role = role, 
     latest_reviews_by_role = attr(annotation_info, "latest_reviews"), 
-    data_timestamps = annotation_info[["data_timestamps"]]
+    data_timestamps = annotation_info[["data_timestamps"]],
+    row_is_outdated
   )
   
   main_review_columns[[REV$ID$LATEST_REVIEW_COL]] <- REV_review_var_to_json(

--- a/tests/testthat/test-review.R
+++ b/tests/testthat/test-review.R
@@ -195,9 +195,11 @@ test_that("REV_compute_status preserves expected behavior", {
   data_timestamps <- c(0, 0, 0)
   
   res_levels <- c("Pending", "Latest Outdated", "Conflict", "Conflict I can fix", "OK")
- 
+
+  dummy_row_is_outdated <- rep(TRUE, length(data_timestamps)) 
+  
   # No reviews 
-  res <- REV_compute_status(dataset_review, role, latest_reviews_by_role, data_timestamps)
+  res <- REV_compute_status(dataset_review, role, latest_reviews_by_role, data_timestamps, dummy_row_is_outdated)
   expect_equal(res, factor(c("Pending", "Pending", "Pending"), levels = res_levels))
  
   # ROLE_1 reviews first row as "A" 
@@ -205,12 +207,12 @@ test_that("REV_compute_status preserves expected behavior", {
   dataset_review[["__role__"]][[1]] <- "ROLE_1"
   latest_reviews_by_role[["ROLE_1"]][["review"]][[1]]  <- "A"
   latest_reviews_by_role[["ROLE_1"]][["timestamp"]][[1]] <- 1
-  res <- REV_compute_status(dataset_review, role, latest_reviews_by_role, data_timestamps)
+  res <- REV_compute_status(dataset_review, role, latest_reviews_by_role, data_timestamps, dummy_row_is_outdated)
   expect_equal(res, factor(c("OK", "Pending", "Pending"), levels = res_levels))
  
   # Review becomes outdated 
   data_timestamps[[1]] <- 2
-  res <- REV_compute_status(dataset_review, role, latest_reviews_by_role, data_timestamps)
+  res <- REV_compute_status(dataset_review, role, latest_reviews_by_role, data_timestamps, dummy_row_is_outdated)
   expect_equal(res, factor(c("Latest Outdated", "Pending", "Pending"), levels = res_levels))
   
   # ROLE_2 reviews first row as "B"
@@ -218,22 +220,22 @@ test_that("REV_compute_status preserves expected behavior", {
   dataset_review[["__role__"]][[1]] <- "ROLE_2"
   latest_reviews_by_role[["ROLE_2"]][["review"]][[1]]  <- "A"
   latest_reviews_by_role[["ROLE_2"]][["timestamp"]][[1]] <- 3
-  res <- REV_compute_status(dataset_review, role, latest_reviews_by_role, data_timestamps)
+  res <- REV_compute_status(dataset_review, role, latest_reviews_by_role, data_timestamps, dummy_row_is_outdated)
   expect_equal(res, factor(c("Conflict", "Pending", "Pending"), levels = res_levels))
  
   # See status from the point of view of ROLE_1
   role <- "ROLE_1"
-  res <- REV_compute_status(dataset_review, role, latest_reviews_by_role, data_timestamps)
+  res <- REV_compute_status(dataset_review, role, latest_reviews_by_role, data_timestamps, dummy_row_is_outdated)
   expect_equal(res, factor(c("Conflict I can fix", "Pending", "Pending"), levels = res_levels))
  
   # See status from the point of view of ROLE_2 
   role <- "ROLE_2"
-  res <- REV_compute_status(dataset_review, role, latest_reviews_by_role, data_timestamps)
+  res <- REV_compute_status(dataset_review, role, latest_reviews_by_role, data_timestamps, dummy_row_is_outdated)
   expect_equal(res, factor(c("Conflict I can fix", "Pending", "Pending"), levels = res_levels))
  
   # See status from the point of view of ROLE_3 
   role <- "ROLE_3"
-  res <- REV_compute_status(dataset_review, role, latest_reviews_by_role, data_timestamps)
+  res <- REV_compute_status(dataset_review, role, latest_reviews_by_role, data_timestamps, dummy_row_is_outdated)
   expect_equal(res, factor(c("Conflict", "Pending", "Pending"), levels = res_levels))
 })
 

--- a/tests/testthat/test-review.R
+++ b/tests/testthat/test-review.R
@@ -196,10 +196,10 @@ test_that("REV_compute_status preserves expected behavior", {
   
   res_levels <- c("Pending", "Latest Outdated", "Conflict", "Conflict I can fix", "OK")
 
-  dummy_row_is_outdated <- rep(TRUE, length(data_timestamps)) 
+  dummy_modified_row_mask <- rep(TRUE, length(data_timestamps)) 
   
   # No reviews 
-  res <- REV_compute_status(dataset_review, role, latest_reviews_by_role, data_timestamps, dummy_row_is_outdated)
+  res <- REV_compute_status(dataset_review, role, latest_reviews_by_role, data_timestamps, dummy_modified_row_mask)
   expect_equal(res, factor(c("Pending", "Pending", "Pending"), levels = res_levels))
  
   # ROLE_1 reviews first row as "A" 
@@ -207,12 +207,12 @@ test_that("REV_compute_status preserves expected behavior", {
   dataset_review[["__role__"]][[1]] <- "ROLE_1"
   latest_reviews_by_role[["ROLE_1"]][["review"]][[1]]  <- "A"
   latest_reviews_by_role[["ROLE_1"]][["timestamp"]][[1]] <- 1
-  res <- REV_compute_status(dataset_review, role, latest_reviews_by_role, data_timestamps, dummy_row_is_outdated)
+  res <- REV_compute_status(dataset_review, role, latest_reviews_by_role, data_timestamps, dummy_modified_row_mask)
   expect_equal(res, factor(c("OK", "Pending", "Pending"), levels = res_levels))
  
   # Review becomes outdated 
   data_timestamps[[1]] <- 2
-  res <- REV_compute_status(dataset_review, role, latest_reviews_by_role, data_timestamps, dummy_row_is_outdated)
+  res <- REV_compute_status(dataset_review, role, latest_reviews_by_role, data_timestamps, dummy_modified_row_mask)
   expect_equal(res, factor(c("Latest Outdated", "Pending", "Pending"), levels = res_levels))
   
   # ROLE_2 reviews first row as "B"
@@ -220,22 +220,22 @@ test_that("REV_compute_status preserves expected behavior", {
   dataset_review[["__role__"]][[1]] <- "ROLE_2"
   latest_reviews_by_role[["ROLE_2"]][["review"]][[1]]  <- "A"
   latest_reviews_by_role[["ROLE_2"]][["timestamp"]][[1]] <- 3
-  res <- REV_compute_status(dataset_review, role, latest_reviews_by_role, data_timestamps, dummy_row_is_outdated)
+  res <- REV_compute_status(dataset_review, role, latest_reviews_by_role, data_timestamps, dummy_modified_row_mask)
   expect_equal(res, factor(c("Conflict", "Pending", "Pending"), levels = res_levels))
  
   # See status from the point of view of ROLE_1
   role <- "ROLE_1"
-  res <- REV_compute_status(dataset_review, role, latest_reviews_by_role, data_timestamps, dummy_row_is_outdated)
+  res <- REV_compute_status(dataset_review, role, latest_reviews_by_role, data_timestamps, dummy_modified_row_mask)
   expect_equal(res, factor(c("Conflict I can fix", "Pending", "Pending"), levels = res_levels))
  
   # See status from the point of view of ROLE_2 
   role <- "ROLE_2"
-  res <- REV_compute_status(dataset_review, role, latest_reviews_by_role, data_timestamps, dummy_row_is_outdated)
+  res <- REV_compute_status(dataset_review, role, latest_reviews_by_role, data_timestamps, dummy_modified_row_mask)
   expect_equal(res, factor(c("Conflict I can fix", "Pending", "Pending"), levels = res_levels))
  
   # See status from the point of view of ROLE_3 
   role <- "ROLE_3"
-  res <- REV_compute_status(dataset_review, role, latest_reviews_by_role, data_timestamps, dummy_row_is_outdated)
+  res <- REV_compute_status(dataset_review, role, latest_reviews_by_role, data_timestamps, dummy_modified_row_mask)
   expect_equal(res, factor(c("Conflict", "Pending", "Pending"), levels = res_levels))
 })
 


### PR DESCRIPTION
This PR addresses the one known source of discrepancy left between the dv.listings review "Status" column and the orange highlighting. There's a comment in the code that explains the strategy.

# Critical checks

- [ ] Is the test version number correct (x.x.x-9000)? 

- [ ] DESCRIPTION file

- [ ] NEWS.md

- [ ] Does the build pass?

---

## Documentation

Does it include the following sections?

- [ ] Module introduction with features
  - [ ] (O) Screenshots

- [ ] Installation details

- [ ] Explanation of function arguments

- [ ] Data specifications and requirements

- [ ] Different possible visualizations

- [ ] Are the changes/new features included in NEWS.md?
  - [ ] (O) Screenshots

- [ ] (O) Explanation of input menus

- [ ] (O) Short articles on building the app, compatibility with other modules, known bugs,...

---

## QC Report

- [ ] Does it include a QC Report with positive outcome?

- [ ] Are the new features reflected accordingly in the specs?

---

## API conventions

- [ ] Follows API convention
