### PR TITLE
Revert "Cosmetic NAs", as it doesn't compose with DT::replaceData.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: dv.listings
 Type: Package
 Title: Data listings module
-Version: 4.3.4-9008
+Version: 4.3.4-9009
 Authors@R: 
     c(
       person("Boehringer-Ingelheim Pharma GmbH & Co.KG", role = c("cph", "fnd")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# dv.listings 4.3.4-9009
+- Revert NA highlighting
+
 # dv.listings 4.3.4-9008
 - Review functionality:
   - Remove column change highlighting from rows that have been modified but restored afterwards

--- a/R/mod_listings.R
+++ b/R/mod_listings.R
@@ -682,19 +682,6 @@ listings_server <- function(module_id,
           colResize = list(),
           processing = TRUE,
           initComplete = htmlwidgets::JS(init_complete_js),
-          rowCallback = htmlwidgets::JS(
-            # Source - https://stackoverflow.com/a/58526580
-            # Posted by Stéphane Laurent
-            # Retrieved 2026-04-09, License - CC BY-SA 4.0
-            "function(row, data){",
-            "  for(var i=0; i<data.length; i++){",
-            "    if(data[i] === null){",
-            "      $('td:eq('+i+')', row).html('NA')",
-            "        .css({'color': 'rgb(151,151,151)', 'font-style': 'italic'});",
-            "    }",
-            "  }",
-            "}"
-          ),
           drawCallback = htmlwidgets::JS("
             function (settings) {  
             const table_wrapper = settings.nTableWrapper;


### PR DESCRIPTION
This reverts commit 4882bcf7ea81994abd6e433a2143178566da772f.

The functionality we're removing changes the highlighting of "null" values to _NA_. The problem here is that the javascript code is unaware of changes to the underlying data triggered with `DT::replaceData`. That's the mechanism that the review functionality is forced to use.

There was no user request for this cosmetic feature, so rather than fixing it, I'm reverting it.

# Hotfix checklist

- [x] Bumped minor version number on both DESCRIPTION and NEWS.md

- [x] Build passes pipeline checks

- [x] The new changes do not affect the API

- [x] The new changes do not affect the documentation (including screenshots)

- [x] The new changes do not impact the QC report

