### PR TITLE
Address deprecation warnings

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: dv.listings
 Type: Package
 Title: Data listings module
-Version: 4.3.4-9013
+Version: 4.3.4-9014
 Authors@R: 
     c(
       person("Boehringer-Ingelheim Pharma GmbH & Co.KG", role = c("cph", "fnd")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: dv.listings
 Type: Package
 Title: Data listings module
-Version: 4.3.4-9012
+Version: 4.3.4-9013
 Authors@R: 
     c(
       person("Boehringer-Ingelheim Pharma GmbH & Co.KG", role = c("cph", "fnd")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# dv.listings 4.3.4-9013
+- Excel export:
+  - Ensure valid sheet names
+
 # dv.listings 4.3.4-9012
 - [NOT USER-FACING] Delegate some EEF logic into dv.manager
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# dv.listings 4.3.4-9014
+- [NOT USER-FACING] Address dv.manager deprecation warning messages
+
 # dv.listings 4.3.4-9013
 - Excel export:
   - Ensure valid sheet names

--- a/R/export_helpers.R
+++ b/R/export_helpers.R
@@ -427,10 +427,7 @@ prep_export_data <- function(data_selection, current_data, data_selection_name, 
     data_to_download <- dataset_list
   }
 
-  shortened_names <- shorten_entries(
-    paste0(names(data_to_download), " (", get_labels(data_to_download), ")"),
-    as.integer(31) # name has to be shortened to 31 characters due to Excel's sheet name limit
-  )
+  labeled_dataframe_names <- paste0(names(data_to_download), " (", get_labels(data_to_download), ")")
 
   data_to_download <- local({
     res <- list()
@@ -451,11 +448,35 @@ prep_export_data <- function(data_selection, current_data, data_selection_name, 
     return(res)
   })
     
-  names(data_to_download) <- shortened_names
+  names(data_to_download) <- labeled_dataframe_names
 
   return(data_to_download)
 }
 
+sanitize_excel_sheet_names <- function(sheet_names) {
+  tweak_invalid_excel_sheet_name <- function(s) {
+    s <- gsub(r"([\\/?*:\[\]])", " ", s, perl = TRUE) # forbidden characters \ / ? * : [ ] replaced with whitespace
+    s <- trimws(s, whitespace = "'")                  # forbidden only at the beginning and end
+    if (identical(s, "History")) s <- "History."       # "History" is just not an allowed name
+    if (nchar(trimws(s)) == 0) s <- "."               # pure whitespaced not allowed
+    return(s)
+  }
+  
+  sheet_names <- sapply(sheet_names, tweak_invalid_excel_sheet_name, USE.NAMES = FALSE)
+  sheet_names <- shorten_entries(sheet_names, as.integer(31))
+  if (anyDuplicated(tolower(sheet_names))) { # edge case: duplication when case is ignored
+    sheet_names <- sprintf("(%d) %s", seq_along(sheet_names), sheet_names) # prepend a unique number to all names
+    sheet_names <- shorten_entries(sheet_names, as.integer(31)) # numbering could push us over limit of 31 characters
+  }
+  
+  return(sheet_names)
+}
+
+sanitize_dataset_list_for_excel_export <- function(dataset_list) {
+  sanitized_sheet_names <- sanitize_excel_sheet_names(names(dataset_list))
+  names(dataset_list) <- sanitized_sheet_names
+  return(dataset_list)
+}
 
 #' Internal helper function which performs the download as .xlsx file.
 #'
@@ -487,6 +508,8 @@ excel_export <- function(data_to_download, file, intended_use_label) {
     }
     return(x)
   })
+  
+  data_to_download <- sanitize_dataset_list_for_excel_export(data_to_download)
 
   # Add first sheet as title page
   title_page <- data.frame(c(EXP$EXP_TITLE, intended_use_label))

--- a/R/mod_listings.R
+++ b/R/mod_listings.R
@@ -878,7 +878,7 @@ mod_listings <- function(
       listings_UI(module_id = module_id)
     },
     server = function(afmm) {
-      dataset_list <- shiny::reactive(afmm$filtered_dataset()[dataset_names])
+      dataset_list <- shiny::reactive(afmm$filtered_dataset_list()[dataset_names])
       
       on_sbj_click_fun <- NULL
       if (!is.null(receiver_id)) {
@@ -888,7 +888,9 @@ mod_listings <- function(
       if (is.list(review)) {
         # These afmm fields are only required for the review functionality, so we bundle them in the `review` list
         review[["data"]] <- lapply(afmm[["data"]], function(e) if (is.function(e)) e() else e)
-        review[["selected_dataset"]] <- afmm[["dataset_metadata"]][["name"]]
+        review[["selected_dataset"]] <- shiny::reactive(
+          attr(afmm[["unfiltered_dataset_list_with_filter_info"]]()[["unfiltered_dataset_list"]], "dataset_list_name")
+        )
         
         # Prevent and warn against multiple `dv.listings` instances with active review functionality.
         #
@@ -921,7 +923,18 @@ mod_listings <- function(
         dataset_list = dataset_list,
         default_vars = default_vars,
         footers = footers,
-        dataset_metadata = afmm$dataset_metadata,
+        dataset_metadata = list(
+          name = shiny::reactive(
+            attr(
+              afmm[["unfiltered_dataset_list_with_filter_info"]]()[["unfiltered_dataset_list"]], "dataset_list_name"
+            )
+          ),
+          date_range = shiny::reactive(
+            attr(
+              afmm[["unfiltered_dataset_list_with_filter_info"]]()[["unfiltered_dataset_list"]], "date_range"
+            )
+          )
+        ),
         pagination = pagination,
         module_id = module_id,
         intended_use_label = intended_use_label,

--- a/R/mod_simple_listing.R
+++ b/R/mod_simple_listing.R
@@ -44,7 +44,7 @@ mod_simple_listing <- function(dataset_name, module_id) {
     ui = simple_listing_UI,
     server = function(afmm) {
       simple_listing_server(
-        dataset = shiny::reactive(afmm$filtered_dataset()[[dataset_name]]),
+        dataset = shiny::reactive(afmm$filtered_dataset_list()[[dataset_name]]),
         module_id = module_id
       )
     },

--- a/inst/validation/specs.R
+++ b/inst/validation/specs.R
@@ -25,6 +25,7 @@ export <- specs_list(
   "export" = "dv.listings includes a button to export the listing(s). A click to the button envokes a pop-up to appear that allows the user to decide whether the download should only contain the displayed listing or all available listings, provide a file name (defaulted to the dataset name), and select from available file types.",
   "export_active_listing" = "For downloading only the currently active listing, the listing will be saved as it is displayed, either in .xlsx or .pdf format. In case filters were applied, the downloaded output will only contain the filtered data.",
   "export_excel" = "For downloading all listings, the tables can be saved in .xlsx format only without considering local filters. Each listing will be placed in an individual worksheet within the file.",
+  "export_valid_excel_sheet_names" = "Export modifies dataframe labels to accomodate excel sheet name restrictions",
   "export_pdf" = "For downloading in .pdf format, users can select one or multiple reference column(s), which will be displayed on all document pages.",
   "export_footers" = "If footnotes are specified, they will be included at the end of PDF listings and under each excel page"
 )

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -10,7 +10,7 @@ vdoc <- local({
 specs <- vdoc[["specs"]]
 #  validation (F)
 
-# YT#VH0bf15c0db690dfd3fac713f3c9b61f66#VH00000000000000000000000000000000#
+# YT#VH3b377124b258c8f7c5c9951207153ecb#VH0bf15c0db690dfd3fac713f3c9b61f66#
 
 #' Test harness for communication with `dv.papo`.
 #'
@@ -23,12 +23,17 @@ test_communication_with_papo <- function(mod, data, trigger_input_id, papo_spec_
 
   afmm <- list(
     data = list(DS = data),
-    unfiltered_dataset = datasets,
-    filtered_dataset = datasets,
+    unfiltered_dataset = datasets,                                         # deprecated by dv.manager >= 3.1.0
+    unfiltered_dataset_list = datasets,                                    # encouraged by dv.manager >= 3.1.0
+    filtered_dataset = datasets,                                           # deprecated by dv.manager >= 3.1.0
+    filtered_dataset_list = datasets,                                      # encouraged by dv.manager >= 3.1.0
     module_output = function() list(),
     module_names = list(papo = "Papo"),
     utils = list(switch2mod = function(id) NULL),
-    dataset_metadata = list(name = shiny::reactive("dummy_dataset_name"))
+    dataset_metadata = list(name = shiny::reactive("dummy_dataset_name")), # deprecated on dv.manager >= 3.1.0
+    unfiltered_dataset_list_with_filter_info = shiny::reactive(            # encouraged by dv.manager >= 3.1.0
+      list(unfiltered_dataset_list = structure("WHATEVER", dataset_list_name = "dummy_dataset_name"))
+    )
   )
 
   app_ui <- function() {

--- a/tests/testthat/test-export_helpers.R
+++ b/tests/testthat/test-export_helpers.R
@@ -525,27 +525,6 @@ test_that("prep_export_data() performs the correct transformation in the multipl
   expect_identical(res[[3]], set_labels(data.frame(sapply(dataset_list_valid[[3]], as.character))))
 })
 
-test_that("prep_export_data() shortens dataset names if they exceed Excel's sheet name limit of 31 characters", {
-  # arguments
-  data_selection_valid <- "all"
-  dataset_list_valid <- list("dummy1" = simple_dummy, "dummy2" = simple_dummy[1:5], "dummy3" = simple_dummy[5:10])
-  attributes(dataset_list_valid$dummy1)$label <- "This is a very long dataset label"
-  attributes(dataset_list_valid$dummy2)$label <- "This is another very long dataset label"
-  attributes(dataset_list_valid$dummy3)$label <- "Short label"
-  current_data_valid <- dataset_list_valid[[1]]
-  data_selection_name_valid <- names(dataset_list_valid)[1]
-
-  # result
-  res <- nchar(
-    names(prep_export_data(data_selection_valid, current_data_valid, data_selection_name_valid, dataset_list_valid,
-                           footers = NULL))
-  )
-
-  # perform tests
-  expect_identical(res, as.integer(c(31, 31, 20)))
-})
-
-
 test_that("excel_export() throws an error when argument types mismatch", {
   # arguments
   data_to_download_valid <- list("dummy1" = simple_dummy, "dummy2" = simple_dummy[1:5])
@@ -676,3 +655,54 @@ test_that("warn_function() throws an error when argument types mismatch", {
 test_that("warn_function() triggers the correct feedback", {
   skip("Highlighting problematic user input is not tested in an automated way.")
 })
+
+test_that("sanitize_excel_sheet_names returns conforming excel sheet names" |>
+            vdoc[["add_spec"]](specs$export_valid_excel_sheet_names), {
+  tests <- list(
+    valid = list(
+      q = c("Sheet1", "Report_2035", "ai ai ai"),
+      a = c("Sheet1", "Report_2035", "ai ai ai")
+    )
+    , forbidden_chars = list(
+      q = c("N/A", "Report:2035", "Outdated?", "a[[b]]", "b\\a*c"),
+      a = c("N A", "Report 2035", "Outdated ", "a  b  ", "b a c")
+    )
+    , leading_trailing_single_quotes = list(
+      q = c("'Sheet1'", "Sheet'2", "'Sheet'3'''"),
+      a = c("Sheet1", "Sheet'2", "Sheet'3")
+    )
+    , history = list(
+      q = c("History", "History2", "Our History"),
+      a = c("History.", "History2", "Our History")
+    )
+    , whitespace = list(
+      q = c("", "   ", "\t"),
+      a = c("(1) .", "(2) .", "(3) .")
+    )
+    , dup_names = list(
+      q = c("Don't shout", "don't shout", "DON'T SHOUT"),
+      a = c("(1) Don't shout", "(2) don't shout", "(3) DON'T SHOUT")
+    )
+    , nchar_limit1 = list(
+      q = c("foo 56789 123456789 123456789 1excess chars",
+            "bar 56789 123456789 123456789 1excess chars",
+            "baz 56789 123456789 123456789 1excess chars"),
+      a = c(
+        "foo 56789 123456789 12345678...",
+        "bar 56789 123456789 12345678...",
+        "baz 56789 123456789 12345678..."
+      )
+    )
+    , nchar_limit2 = list(
+      q = rep("123456789 123456789 123456789 1excess chars", 3),
+      a = c(
+        "(1) 123456789 123456789 1234...",
+        "(2) 123456789 123456789 1234...",
+        "(3) 123456789 123456789 1234..."
+      )
+    )
+  )
+  
+  for(test in tests) testthat::expect_identical(sanitize_excel_sheet_names(test[["q"]]), test[["a"]])
+})
+


### PR DESCRIPTION
@zsigmas This one should wait until #79 is approved and merged to `test`, as it builds on top of it.

On top of the expected tweaks to fix deprecation warnings, you'll see that I've tweaked the `test_communication_with_papo` snippet, because it needed to imitate the new fields in the `afmm` interface. I haven't tried these tweaks in any other module, yet. I believe `dv.tables` is also in the process of clearing these warnings and it also relies on this same snippet. With a bit of luck, copying and pasting it there will work.

# Critical checks

- [ ] Is the test version number correct (x.x.x-9000)? 

- [ ] DESCRIPTION file

- [ ] NEWS.md

- [ ] Does the build pass?

---

## Documentation

Does it include the following sections?

- [ ] Module introduction with features
  - [ ] (O) Screenshots

- [ ] Installation details

- [ ] Explanation of function arguments

- [ ] Data specifications and requirements

- [ ] Different possible visualizations

- [ ] Are the changes/new features included in NEWS.md?
  - [ ] (O) Screenshots

- [ ] (O) Explanation of input menus

- [ ] (O) Short articles on building the app, compatibility with other modules, known bugs,...

---

## QC Report

- [ ] Does it include a QC Report with positive outcome?

- [ ] Are the new features reflected accordingly in the specs?

---

## API conventions

- [ ] Follows API convention
